### PR TITLE
add-querySlotNo-monadBlockchain

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Update `queryTip` and `queryTipSlotNo` in `Convex.Devnet.NodeQueries` to also return `SlotLength`.
-* Add `querySlotNo` to `MonadBlockchain` typeclass and update both blockchain and mockchain implementations.
-* Add `utcTimeToPosixTime` in `Convex.Utils`.
 
 ### Added
 
@@ -23,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `convex-devnet`: Some haddocks in `Convex.Devnet.NodeQueries`
 * `convex-mockchain`:
   - `Convex.MockChain`: Support for profiling plutus scripts. `evaluateTx` returns the script contexts for a transaction. These can be turned into a fully applied script with `fullyAppliedScript`
+* Add `querySlotNo` to `MonadBlockchain` typeclass and update both blockchain and mockchain implementations.
+* Add `utcTimeToPosixTime` in `Convex.Utils`.
 
 ## [0.0.1] - 2023-04-26
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Update `queryTip` and `queryTipSlotNo` in `Convex.Devnet.NodeQueries` to also return `SlotLength`.
 * Add `querySlotNo` to `MonadBlockchain` typeclass and update both blockchain and mockchain implementations.
+* Add `utcTimeToPosixTime` in `Convex.Utils`.
 
 ### Added
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*  Update `queryTip` and `queryTipSlotNo` in `Convex.Devnet.NodeQueries` to also return `SlotLength`.
+* Update `queryTip` and `queryTipSlotNo` in `Convex.Devnet.NodeQueries` to also return `SlotLength`.
+* Add `querySlotNo` to `MonadBlockchain` typeclass and update both blockchain and mockchain implementations.
 
 ### Added
 

--- a/src/base/lib/Convex/Utils.hs
+++ b/src/base/lib/Convex/Utils.hs
@@ -23,6 +23,7 @@ module Convex.Utils(
   slotToUtcTime,
   utcTimeToSlot,
   utcTimeToSlotUnsafe,
+  utcTimeToPosixTime,
   posixTimeToSlot,
   posixTimeToSlotUnsafe
 ) where
@@ -55,8 +56,10 @@ import           Data.Proxy                               (Proxy (..))
 import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import           Data.Time.Clock                          (NominalDiffTime,
-                                                           UTCTime)
-import           Data.Time.Clock.POSIX                    (posixSecondsToUTCTime)
+                                                           UTCTime,
+                                                           nominalDiffTimeToSeconds)
+import           Data.Time.Clock.POSIX                    (posixSecondsToUTCTime,
+                                                           utcTimeToPOSIXSeconds)
 import qualified Ouroboros.Consensus.HardFork.History     as Consensus
 import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 import qualified Plutus.V1.Ledger.Time                    as PV1
@@ -137,6 +140,9 @@ slotToUtcTime (toLedgerEpochInfo -> info) systemStart slot = epochInfoSlotToUTCT
 utcTimeToSlot :: C.EraHistory mode -> C.SystemStart -> UTCTime -> Either String (SlotNo, NominalDiffTime, NominalDiffTime)
 utcTimeToSlot (C.EraHistory _ interpreter) systemStart t = first show $
   Qry.interpretQuery interpreter (Qry.wallclockToSlot (Time.toRelativeTime systemStart t))
+
+utcTimeToPosixTime :: UTCTime -> PV1.POSIXTime
+utcTimeToPosixTime =  PV1.POSIXTime . (truncate . (* 1000)) . nominalDiffTimeToSeconds . utcTimeToPOSIXSeconds
 
 {-| Convert a 'PV1.POSIXTime' to slot no. Returns the time spent and time left in this slot.
 -}

--- a/src/base/lib/Convex/Utils.hs
+++ b/src/base/lib/Convex/Utils.hs
@@ -45,7 +45,8 @@ import qualified Cardano.Slotting.Time                    as Time
 import           Control.Monad                            (void, when)
 import           Control.Monad.Except                     (runExcept)
 import           Control.Monad.IO.Class                   (MonadIO (..))
-import           Convex.PlutusLedger                      (unTransPOSIXTime)
+import           Convex.PlutusLedger                      (transPOSIXTime,
+                                                           unTransPOSIXTime)
 import           Data.Aeson                               (Result (..),
                                                            fromJSON, object,
                                                            (.=))
@@ -56,8 +57,7 @@ import           Data.Proxy                               (Proxy (..))
 import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import           Data.Time.Clock                          (NominalDiffTime,
-                                                           UTCTime,
-                                                           nominalDiffTimeToSeconds)
+                                                           UTCTime)
 import           Data.Time.Clock.POSIX                    (posixSecondsToUTCTime,
                                                            utcTimeToPOSIXSeconds)
 import qualified Ouroboros.Consensus.HardFork.History     as Consensus
@@ -142,7 +142,7 @@ utcTimeToSlot (C.EraHistory _ interpreter) systemStart t = first show $
   Qry.interpretQuery interpreter (Qry.wallclockToSlot (Time.toRelativeTime systemStart t))
 
 utcTimeToPosixTime :: UTCTime -> PV1.POSIXTime
-utcTimeToPosixTime =  PV1.POSIXTime . (truncate . (* 1000)) . nominalDiffTimeToSeconds . utcTimeToPOSIXSeconds
+utcTimeToPosixTime =  transPOSIXTime . utcTimeToPOSIXSeconds
 
 {-| Convert a 'PV1.POSIXTime' to slot no. Returns the time spent and time left in this slot.
 -}

--- a/src/devnet/lib/Convex/Devnet/NodeQueries.hs
+++ b/src/devnet/lib/Convex/Devnet/NodeQueries.hs
@@ -29,8 +29,8 @@ import           Cardano.Api                                        (Address,
                                                                      TxIn, UTxO)
 import qualified Cardano.Api                                        as C
 import           Cardano.Slotting.Slot                              (WithOrigin)
-import           Cardano.Slotting.Time                              (SystemStart,
-                                                                     slotLengthToMillisec)
+import           Cardano.Slotting.Time                              (SlotLength,
+                                                                     SystemStart)
 import           Control.Concurrent                                 (threadDelay)
 import           Control.Exception                                  (Exception,
                                                                      throwIO)
@@ -55,9 +55,6 @@ data QueryException
   deriving (Eq, Show)
 
 instance Exception QueryException
-
-newtype SlotLength = SlotLength Integer
-  deriving (Eq, Show)
 
 -- | Get the 'SystemStart' from the node
 querySystemStart ::
@@ -115,7 +112,7 @@ queryTip networkId socket = queryLocalState (C.QueryChainPoint C.CardanoMode) ne
       (EraHistory _ interpreter) <- queryEraHistory networkId socket
       case interpretQuery interpreter (slotToSlotLength slotNo) of
         Left err      -> failure $ "queryTip: Failed with " <> show err
-        Right slength -> pure $ SlotLength $ slotLengthToMillisec slength
+        Right slength -> pure $ slength
 
 -- | Get the slot no of the current tip from the node
 queryTipSlotNo ::

--- a/src/mockchain/lib/Convex/MockChain.hs
+++ b/src/mockchain/lib/Convex/MockChain.hs
@@ -361,6 +361,9 @@ instance Monad m => MonadBlockchain (MockchainT m) where
   networkId = MockchainT (asks npNetworkId)
   querySystemStart = MockchainT (asks npSystemStart)
   queryEraHistory = MockchainT (asks npEraHistory)
+  querySlotNo = MockchainT $ do
+    st <- get
+    pure $ st ^. env . L.slot
 
 instance Monad m => MonadMockchain (MockchainT m) where
   modifySlot f = MockchainT $ do

--- a/src/mockchain/lib/Convex/MockChain.hs
+++ b/src/mockchain/lib/Convex/MockChain.hs
@@ -363,7 +363,8 @@ instance Monad m => MonadBlockchain (MockchainT m) where
   queryEraHistory = MockchainT (asks npEraHistory)
   querySlotNo = MockchainT $ do
     st <- get
-    pure $ st ^. env . L.slot
+    slength <- asks npSlotLength
+    return (st ^. env . L.slot, slength)
 
 instance Monad m => MonadMockchain (MockchainT m) where
   modifySlot f = MockchainT $ do


### PR DESCRIPTION
- [x] Adding querySlotNo to MonadBlockchain type class
- [x] Update blockchain and mockchain implementation
- [x] Using `SlotLength` type defined in `Cardano.Slotting.Time `instead of custom type
- [x] Add `utcTimeToPosixTime` in `Convex.Utils`
- [x] update change log