### PR TITLE
Additional PlutusV2 functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add a "change output" parameter to the coin selection functions
 * Set `slotLength` in `Convex.MockChain.Defaults` to 1 second (it was set to 1000 seconds by accident)
 * Change base monad of `mockchainSucceeds` to `IO`
+* Change `_PlutusScriptWitness` in `Convex.Lenses` to `_PlutusScriptWitnessV1`
 
 ### Added
 
@@ -36,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Convex.BuildTx`:
   - Add a monadic (writer) interface for building transactions
   - Add `addRequiredSignature`, `prependTxOut`, `payToPlutusV2InlineDatum`, `spendPlutusV2InlineDatum` functions
+  - Add `spendPlutusV2RefWithInlineDatum`, `spendPlutusV2RefWithoutInRef` and `spendPlutusV2RefWithoutInRefInlineDatum` functions
+  - Add `payToPlutusV2InlineWithDatum` and `payToPlutusV2InlineWithInlineDatum` functions
+
+
 * Add `querySlotNo` to `MonadBlockchain` typeclass and update both blockchain and mockchain implementations.
 * Add `utcTimeToPosixTime`, `toShelleyPaymentCredential` in `Convex.Utils`.
 * Considering explicit error type `MonadBlockchainError` for `MonadBlockchainCardanoNodeT` to enable proper error handling by caller.
@@ -44,11 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `Convex.Wallet.Operator` for managing credentials
 * `convex-coin-selection`:
   - Add `Convex.Query` for UTxO queries, add convex-wallet backend for operator UTxOs
+* Add `_PlutusScriptWitnessV2` to `Convex.Lenses`
+
+
 
 ### Deleted
 
 * Deleted the `trading-bot` and `muesli` packages.
-* Deleted `spendPlutusV1Ref` and `spendPlutusV2Ref` as they don't make sense.
+* Deleted `spendPlutusV1Ref` as it does not make sense.
 
 ## [0.0.1] - 2023-04-26
 

--- a/src/base/lib/Convex/Lenses.hs
+++ b/src/base/lib/Convex/Lenses.hs
@@ -51,7 +51,8 @@ module Convex.Lenses(
   -- ** Witnesses
   _KeyWitness,
   _ScriptWitness,
-  _PlutusScriptWitness,
+  _PlutusScriptWitnessV1,
+  _PlutusScriptWitnessV2,
 
   -- ** Build tx
   _BuildTxWith,
@@ -440,13 +441,22 @@ _ScriptData = prism' from to where
   from :: a -> C.ScriptData
   from = Scripts.toScriptData
 
-_PlutusScriptWitness :: forall era witctx. Prism' (C.ScriptWitness witctx era) (C.ScriptLanguageInEra C.PlutusScriptV1 era, C.PlutusScriptVersion C.PlutusScriptV1, C.PlutusScriptOrReferenceInput C.PlutusScriptV1, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
-_PlutusScriptWitness = prism' from to where
+_PlutusScriptWitnessV1 :: forall era witctx. Prism' (C.ScriptWitness witctx era) (C.ScriptLanguageInEra C.PlutusScriptV1 era, C.PlutusScriptVersion C.PlutusScriptV1, C.PlutusScriptOrReferenceInput C.PlutusScriptV1, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
+_PlutusScriptWitnessV1 = prism' from to where
   from :: (C.ScriptLanguageInEra C.PlutusScriptV1 era, C.PlutusScriptVersion C.PlutusScriptV1, C.PlutusScriptOrReferenceInput C.PlutusScriptV1, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits) -> C.ScriptWitness witctx era
   from (lang, v, i, dtr, red, ex) = C.PlutusScriptWitness lang v i dtr red ex
 
   to :: C.ScriptWitness witctx era -> Maybe (C.ScriptLanguageInEra C.PlutusScriptV1 era, C.PlutusScriptVersion C.PlutusScriptV1, C.PlutusScriptOrReferenceInput C.PlutusScriptV1, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
   to (C.PlutusScriptWitness C.PlutusScriptV1InBabbage v i dtr red ex) = Just (C.PlutusScriptV1InBabbage, v, i, dtr, red, ex)
+  to _ = Nothing
+
+_PlutusScriptWitnessV2 :: forall era witctx. Prism' (C.ScriptWitness witctx era) (C.ScriptLanguageInEra C.PlutusScriptV2 era, C.PlutusScriptVersion C.PlutusScriptV2, C.PlutusScriptOrReferenceInput C.PlutusScriptV2, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
+_PlutusScriptWitnessV2 = prism' from to where
+  from :: (C.ScriptLanguageInEra C.PlutusScriptV2 era, C.PlutusScriptVersion C.PlutusScriptV2, C.PlutusScriptOrReferenceInput C.PlutusScriptV2, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits) -> C.ScriptWitness witctx era
+  from (lang, v, i, dtr, red, ex) = C.PlutusScriptWitness lang v i dtr red ex
+
+  to :: C.ScriptWitness witctx era -> Maybe (C.ScriptLanguageInEra C.PlutusScriptV2 era, C.PlutusScriptVersion C.PlutusScriptV2, C.PlutusScriptOrReferenceInput C.PlutusScriptV2, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
+  to (C.PlutusScriptWitness C.PlutusScriptV2InBabbage v i dtr red ex) = Just (C.PlutusScriptV2InBabbage, v, i, dtr, red, ex)
   to _ = Nothing
 
 _TxValidityNoLowerBound :: forall era. Prism' (C.TxValidityLowerBound era) ()


### PR DESCRIPTION
- [x] Adding function`spendPlutusV2RefWithInlineDatum` to allow the spending a script utxo with an inline datum in a reference script context
- [x] Adding function `spendPlutusV2RefWithoutInRef` to allow the spending of a script utxo without specifying the reference script in the reference input list. This function is handy mainly when the utxo for the reference script is also consumed in the same transaction
- [x] Adding function `spendPlutusV2RefWithoutInRefInlineDatum`. This function is similar to `spendPlutusV2RefWithoutInRef` except that the spending script utxo has an inline datum.
- [x] Adding function `payToPlutusV2InlineWithDatum` to allow the creation of  a reference script at a script utxo with a datum
- [x] Adding function `payToPlutusV2InlineWithInlineDatum`. This function is similar to  `payToPlutusV2InlineWithDatum` except that an inline datum is specified instead.
- [x] Renaming function `_PlutusScriptWitness` to  `_PlutusScriptWitnessV1`
- [x] Adding function  `_PlutusScriptWitnessV2` for Plutus V2 scripts in the witness map

