### PR TITLE
Additional Plutusv2 functions - main patch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add a "change output" parameter to the coin selection functions
 * Set `slotLength` in `Convex.MockChain.Defaults` to 1 second (it was set to 1000 seconds by accident)
 * Change base monad of `mockchainSucceeds` to `IO`
+* Change `_PlutusScriptWitness` in `Convex.Lenses` to `_PlutusScriptWitnessV1`
 
 ### Added
 
@@ -39,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Convex.BuildTx`:
   - Add a monadic (writer) interface for building transactions
   - Add `addRequiredSignature`, `prependTxOut`, `payToPlutusV2InlineDatum`, `spendPlutusV2InlineDatum` functions
+  - Add `spendPlutusV2RefWithInlineDatum`, `spendPlutusV2RefWithoutInRef` and `spendPlutusV2RefWithoutInRefInlineDatum` functions
+  - Add `payToPlutusV2InlineWithDatum` and `payToPlutusV2InlineWithInlineDatum` functions
+
+
 * Add `querySlotNo` to `MonadBlockchain` typeclass and update both blockchain and mockchain implementations.
 * Add `utcTimeToPosixTime`, `toShelleyPaymentCredential` in `Convex.Utils`.
 * Considering explicit error type `MonadBlockchainError` for `MonadBlockchainCardanoNodeT` to enable proper error handling by caller.
@@ -47,11 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `Convex.Wallet.Operator` for managing credentials
 * `convex-coin-selection`:
   - Add `Convex.Query` for UTxO queries, add convex-wallet backend for operator UTxOs
+* Add `_PlutusScriptWitnessV2` to `Convex.Lenses`
+
+
 
 ### Deleted
 
 * Deleted the `trading-bot` and `muesli` packages.
-* Deleted `spendPlutusV1Ref` and `spendPlutusV2Ref` as they don't make sense.
+* Deleted `spendPlutusV1Ref` as it does not make sense.
 
 ## [0.0.1] - 2023-04-26
 

--- a/src/base/lib/Convex/Lenses.hs
+++ b/src/base/lib/Convex/Lenses.hs
@@ -52,7 +52,8 @@ module Convex.Lenses(
   -- ** Witnesses
   _KeyWitness,
   _ScriptWitness,
-  _PlutusScriptWitness,
+  _PlutusScriptWitnessV1,
+  _PlutusScriptWitnessV2,
 
   -- ** Build tx
   _BuildTxWith,
@@ -443,13 +444,22 @@ _ScriptData = prism' from to where
   from :: a -> C.ScriptData
   from = Scripts.toScriptData
 
-_PlutusScriptWitness :: forall era witctx. Prism' (C.ScriptWitness witctx era) (C.ScriptLanguageInEra C.PlutusScriptV1 era, C.PlutusScriptVersion C.PlutusScriptV1, C.PlutusScriptOrReferenceInput C.PlutusScriptV1, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
-_PlutusScriptWitness = prism' from to where
+_PlutusScriptWitnessV1 :: forall era witctx. Prism' (C.ScriptWitness witctx era) (C.ScriptLanguageInEra C.PlutusScriptV1 era, C.PlutusScriptVersion C.PlutusScriptV1, C.PlutusScriptOrReferenceInput C.PlutusScriptV1, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
+_PlutusScriptWitnessV1 = prism' from to where
   from :: (C.ScriptLanguageInEra C.PlutusScriptV1 era, C.PlutusScriptVersion C.PlutusScriptV1, C.PlutusScriptOrReferenceInput C.PlutusScriptV1, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits) -> C.ScriptWitness witctx era
   from (lang, v, i, dtr, red, ex) = C.PlutusScriptWitness lang v i dtr red ex
 
   to :: C.ScriptWitness witctx era -> Maybe (C.ScriptLanguageInEra C.PlutusScriptV1 era, C.PlutusScriptVersion C.PlutusScriptV1, C.PlutusScriptOrReferenceInput C.PlutusScriptV1, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
   to (C.PlutusScriptWitness C.PlutusScriptV1InBabbage v i dtr red ex) = Just (C.PlutusScriptV1InBabbage, v, i, dtr, red, ex)
+  to _ = Nothing
+
+_PlutusScriptWitnessV2 :: forall era witctx. Prism' (C.ScriptWitness witctx era) (C.ScriptLanguageInEra C.PlutusScriptV2 era, C.PlutusScriptVersion C.PlutusScriptV2, C.PlutusScriptOrReferenceInput C.PlutusScriptV2, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
+_PlutusScriptWitnessV2 = prism' from to where
+  from :: (C.ScriptLanguageInEra C.PlutusScriptV2 era, C.PlutusScriptVersion C.PlutusScriptV2, C.PlutusScriptOrReferenceInput C.PlutusScriptV2, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits) -> C.ScriptWitness witctx era
+  from (lang, v, i, dtr, red, ex) = C.PlutusScriptWitness lang v i dtr red ex
+
+  to :: C.ScriptWitness witctx era -> Maybe (C.ScriptLanguageInEra C.PlutusScriptV2 era, C.PlutusScriptVersion C.PlutusScriptV2, C.PlutusScriptOrReferenceInput C.PlutusScriptV2, C.ScriptDatum witctx, C.ScriptRedeemer, C.ExecutionUnits)
+  to (C.PlutusScriptWitness C.PlutusScriptV2InBabbage v i dtr red ex) = Just (C.PlutusScriptV2InBabbage, v, i, dtr, red, ex)
   to _ = Nothing
 
 _TxValidityNoLowerBound :: forall era. Prism' (C.TxValidityLowerBound era) ()

--- a/src/coin-selection/lib/Convex/BuildTx.hs
+++ b/src/coin-selection/lib/Convex/BuildTx.hs
@@ -29,10 +29,15 @@ module Convex.BuildTx(
   spendPlutusV1,
   spendPlutusV2,
   spendPlutusV2Ref,
+  spendPlutusV2RefWithInlineDatum,
+  spendPlutusV2RefWithoutInRef,
+  spendPlutusV2RefWithoutInRefInlineDatum,
   spendPlutusV2InlineDatum,
   mintPlutusV1,
   mintPlutusV2,
   payToPlutusV2Inline,
+  payToPlutusV2InlineWithInlineDatum,
+  payToPlutusV2InlineWithDatum,
   addReference,
   addCollateral,
   addAuxScript,
@@ -195,11 +200,36 @@ spendPlutusV2InlineDatum txIn s (toHashableScriptData -> red) =
       wit' = C.BuildTxWith (C.ScriptWitness C.ScriptWitnessForSpending wit)
   in setScriptsValid >> addBtx (over L.txIns ((txIn, wit') :))
 
-spendPlutusV2Ref :: forall datum redeemer m. (MonadBuildTx m, Plutus.ToData datum, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> datum -> redeemer -> m ()
-spendPlutusV2Ref txIn refTxIn sh (toHashableScriptData -> dat) (toHashableScriptData -> red) =
-  let wit = C.PlutusScriptWitness C.PlutusScriptV2InBabbage C.PlutusScriptV2 (C.PReferenceScript refTxIn sh) (C.ScriptDatumForTxIn dat) red (C.ExecutionUnits 0 0)
+spendPlutusV2RefBase :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> C.ScriptDatum C.WitCtxTxIn -> redeemer -> m ()
+spendPlutusV2RefBase txIn refTxIn sh dat (toHashableScriptData -> red) =
+  let wit = C.PlutusScriptWitness C.PlutusScriptV2InBabbage C.PlutusScriptV2 (C.PReferenceScript refTxIn sh) dat red (C.ExecutionUnits 0 0)
       wit' = C.BuildTxWith (C.ScriptWitness C.ScriptWitnessForSpending wit)
-  in setScriptsValid >> addReference refTxIn >> addBtx (over L.txIns ((txIn, wit') :))
+  in setScriptsValid >> addBtx (over L.txIns ((txIn, wit') :))
+
+{-| same as spendPlutusV2RefBase but adds the reference script in the reference input list
+-}
+spendPlutusV2RefBaseWithInRef :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> C.ScriptDatum C.WitCtxTxIn -> redeemer -> m ()
+spendPlutusV2RefBaseWithInRef txIn refTxIn sh dat red = spendPlutusV2RefBase txIn refTxIn sh dat red >> addReference refTxIn
+
+spendPlutusV2Ref :: forall datum redeemer m. (MonadBuildTx m, Plutus.ToData datum, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> datum -> redeemer -> m ()
+spendPlutusV2Ref txIn refTxIn sh (toHashableScriptData -> dat) red = spendPlutusV2RefBaseWithInRef txIn refTxIn sh (C.ScriptDatumForTxIn dat) red
+
+{-| same as spendPlutusV2Ref but considers inline datum at the spent utxo
+-}
+spendPlutusV2RefWithInlineDatum :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> redeemer -> m ()
+spendPlutusV2RefWithInlineDatum txIn refTxIn sh red = spendPlutusV2RefBaseWithInRef txIn refTxIn sh C.InlineScriptDatum red
+
+{-| same as spendPlutusV2Ref but does not add the reference script in the reference input list
+This is to cover the case whereby the reference script utxo is expected to be consumed in the same tx.
+-}
+spendPlutusV2RefWithoutInRef :: forall datum redeemer m. (MonadBuildTx m, Plutus.ToData datum, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> datum -> redeemer -> m ()
+spendPlutusV2RefWithoutInRef txIn refTxIn sh (toHashableScriptData -> dat) red = spendPlutusV2RefBase txIn refTxIn sh (C.ScriptDatumForTxIn dat) red
+
+{-| same as spendPlutusV2RefWithoutInRef but considers inline datum at the spent utxo
+-}
+spendPlutusV2RefWithoutInRefInlineDatum :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> redeemer -> m ()
+spendPlutusV2RefWithoutInRefInlineDatum txIn refTxIn sh red = spendPlutusV2RefBase txIn refTxIn sh C.InlineScriptDatum red
+
 
 mintPlutusV1 :: forall redeemer m. (Plutus.ToData redeemer, MonadBuildTx m) => PlutusScript PlutusScriptV1 -> redeemer -> C.AssetName -> C.Quantity -> m ()
 mintPlutusV1 script (toHashableScriptData -> red) assetName quantity =
@@ -265,10 +295,26 @@ payToPlutusV2 network s datum stakeRef vl =
       dt = toHashableScriptData datum
   in payToScriptHash network sh dt stakeRef vl
 
-payToPlutusV2Inline :: MonadBuildTx m => C.AddressInEra C.BabbageEra -> PlutusScript PlutusScriptV2 -> C.Value -> m ()
-payToPlutusV2Inline addr script vl =
-  let txo = C.TxOut addr (C.TxOutValue C.MultiAssetInBabbageEra vl) C.TxOutDatumNone (C.ReferenceScript C.ReferenceTxInsScriptsInlineDatumsInBabbageEra (C.toScriptInAnyLang $ C.PlutusScript C.PlutusScriptV2 script))
+payToPlutusV2InlineBase :: MonadBuildTx m => C.AddressInEra C.BabbageEra -> C.PlutusScript C.PlutusScriptV2 -> C.TxOutDatum C.CtxTx C.BabbageEra -> C.Value -> m ()
+payToPlutusV2InlineBase addr script dat vl =
+  let refScript = C.ReferenceScript C.ReferenceTxInsScriptsInlineDatumsInBabbageEra (C.toScriptInAnyLang $ C.PlutusScript C.PlutusScriptV2 script)
+      txo = C.TxOut addr (C.TxOutValue C.MultiAssetInBabbageEra vl) dat refScript
   in prependTxOut txo
+
+payToPlutusV2Inline :: MonadBuildTx m => C.AddressInEra C.BabbageEra -> PlutusScript PlutusScriptV2 -> C.Value -> m ()
+payToPlutusV2Inline addr script vl = payToPlutusV2InlineBase addr script C.TxOutDatumNone vl
+
+{-| same as payToPlutusV2Inline but also specify an inline datum -}
+payToPlutusV2InlineWithInlineDatum :: forall a m. (MonadBuildTx m, Plutus.ToData a) => C.AddressInEra C.BabbageEra -> C.PlutusScript C.PlutusScriptV2 -> a -> C.Value -> m ()
+payToPlutusV2InlineWithInlineDatum addr script datum vl =
+  let dat = C.TxOutDatumInline C.ReferenceTxInsScriptsInlineDatumsInBabbageEra (toHashableScriptData datum)
+  in payToPlutusV2InlineBase addr script dat vl
+
+{-| same as payToPlutusV2Inline but also specify a datum -}
+payToPlutusV2InlineWithDatum :: forall a m. (MonadBuildTx m, Plutus.ToData a) => C.AddressInEra C.BabbageEra -> C.PlutusScript C.PlutusScriptV2 -> a -> C.Value -> m ()
+payToPlutusV2InlineWithDatum addr script datum vl =
+  let dat = C.TxOutDatumInTx C.ScriptDataInBabbageEra (toHashableScriptData datum)
+  in payToPlutusV2InlineBase addr script dat vl
 
 payToPlutusV2InlineDatum :: forall a m. (MonadBuildTx m, Plutus.ToData a) => NetworkId -> PlutusScript PlutusScriptV2 -> a -> C.StakeAddressReference -> C.Value -> m ()
 payToPlutusV2InlineDatum network script datum stakeRef vl =


### PR DESCRIPTION
- [x] Adding function `spendPlutusV2RefWithInlineDatum` to allow the spending a script utxo with an inline datum in a reference script context
- [x] Adding function `spendPlutusV2RefWithoutInRef` to allow the spending of a script utxo without specifying the reference script in the reference input list. This function is handy mainly when the utxo for the reference script is also consumed in the same transaction
- [x] Adding function `spendPlutusV2RefWithoutInRefInlineDatum.` This function is similar to `spendPlutusV2RefWithoutInRef` except that the spending script utxo has an inline datum.
- [x] Adding function `payToPlutusV2InlineWithDatum` to allow the creation of a reference script at a script utxo with a datum
- [x] Adding function `payToPlutusV2InlineWithInlineDatum.` This function is similar to `payToPlutusV2InlineWithDatum` except that an inline datum is specified instead.
- [x] Renaming function `_PlutusScriptWitness` to `_PlutusScriptWitnessV1`
- [x] Adding function `_PlutusScriptWitnessV2` for Plutus V2 scripts in the witness map