### PR TITLE
Parallelize ci workflow

### DIFF
--- a/.github/actions/haskell-setup-cached/action.yml
+++ b/.github/actions/haskell-setup-cached/action.yml
@@ -1,0 +1,38 @@
+name: Setup cached deps haskell
+description: Setup haskell with cached dependencies
+inputs:
+  fail-on-cache-miss:
+    description: Fail the action if cache entry is not found.
+    default: true
+    required: false
+
+runs:
+  using: composite
+  steps:
+      - name: Setup libsodium and libsecp256k1
+        uses: ./.github/actions/setup-security-libs
+      - name: Set up cabal.project.local
+        shell: bash
+        run: |
+          echo "package cardano-crypto-praos" >> cabal.project.local
+          echo "  flags: -external-libsodium-vrf" >> cabal.project.local
+      - uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: '8.10'
+          cabal-version: '3.6.0.0'
+      - name: Cached Dependencies
+        uses: actions/cache@v3
+        id: cabal-cache
+        continue-on-error: false
+        with:
+          fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
+          path: |
+            cabal.project.local
+            ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ hashFiles('**/*.cabal', '**/cabal.project', 'cabal.project.local') }}          
+      - name: Install dependencies
+        if: steps.cabal-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: cabal build all --only-dependencies
+

--- a/.github/actions/setup-security-libs/action.yml
+++ b/.github/actions/setup-security-libs/action.yml
@@ -1,0 +1,78 @@
+name: Setup security libs
+description: Setup libsodium and libsecp256k1
+runs:
+  using: composite
+  steps:
+      # Update system and install libsystemd-dev    
+      - name: install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev
+      # cache libsodium
+      - name: cache libsodium-1.0.18
+        id: libsodium
+        uses: actions/cache@v3
+        with:
+          path: ~/libsodium-stable
+          key: ${{ runner.os }}-libsodium-1.0.18
+
+      # install libsodium with cache
+      - name: Install cache libsodium-1.0.18
+        shell: bash
+        if: steps.libsodium.outputs.cache-hit == 'true'
+        run: cd ~/libsodium-stable && ./configure && make -j2 && sudo make install
+
+      # download & install libsodium without cache
+      - name: Install libsodium
+        shell: bash
+        if: steps.libsodium.outputs.cache-hit != 'true'
+        run: |
+          wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
+          tar -xvzf libsodium-1.0.18-stable.tar.gz -C ~
+          cd ~/libsodium-stable
+          ./configure
+          make -j2 && make check
+          sudo make install
+          cd -
+
+      # cache secp256K1
+      - name: cache libsecp256k1
+        id: libsecp256k1
+        uses: actions/cache@v3
+        with:
+          path: ~/secp256k1
+          key: libsecp256k1
+
+      # install libsecp256k1 with cache
+      - name: Install cache libsecp256k1
+        shell: bash
+        if: steps.libsecp256k1.outputs.cache-hit == 'true'
+        run: |
+          cd ~/secp256k1
+          ./autogen.sh
+          ./configure --enable-module-schnorrsig --enable-experimental
+          make
+          sudo make install
+          cd -
+
+      # download & install secp256k1 without cache
+      - name: Install libsecp256k1
+        shell: bash
+        if: steps.libsecp256k1.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/bitcoin-core/secp256k1 ~/secp256k1
+          cd ~/secp256k1
+          git checkout ac83be33
+          ./autogen.sh
+          ./configure --enable-module-schnorrsig --enable-experimental
+          make
+          sudo make install
+          cd -
+
+      # set up environment variables
+      - name: Setup environment variables
+        shell: bash
+        run: |
+          echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -6,108 +6,55 @@ on:
       - '.github/workflows/ci-linux.yaml'
       - 'cabal.project'
       - '*/src/**'
+
+# INFO: The following configuration block ensures that only one build runs per branch,
+# which may be desirable for projects with a costly build process.
+# Remove this block from the CI workflow to let each CI job run to completion.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      # install deps.
-      - name: install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsystemd-dev
-
-      # cache libsodium
-      - name: cache libsodium-1.0.18
-        id: libsodium
-        uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - name: Setup haskell and with cached dependencies
+        uses: ./.github/actions/haskell-setup-cached
         with:
-          path: ~/libsodium-stable
-          key: ${{ runner.os }}-libsodium-1.0.18
+          fail-on-cache-miss: false
 
-      # install libsodium with cache
-      - name: Install cache libsodium-1.0.18
-        if: steps.libsodium.outputs.cache-hit == 'true'
-        run: cd ~/libsodium-stable && ./configure && make -j2 && sudo make install
+  build-all:
+    needs: build
+    runs-on: ubuntu-latest      
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup haskell and with cached dependencies
+        uses: ./.github/actions/haskell-setup-cached
+      - name: Build all
+        run: cabal build -j all
+        
+  build-documentation:
+    needs: build
+    runs-on: ubuntu-latest      
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup haskell and with cached dependencies
+        uses: ./.github/actions/haskell-setup-cached
+      - name: Build documentation
+        run: cabal haddock -j all
+        
 
-      # download & install libsodium without cache
-      - name: Install libsodium
-        if: steps.libsodium.outputs.cache-hit != 'true'
+  test-all:
+    needs: build
+    runs-on: ubuntu-latest      
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup haskell and with cached dependencies
+        uses: ./.github/actions/haskell-setup-cached
+      - name: Install integration test dependencies
         run: |
-          wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
-          tar -xvzf libsodium-1.0.18-stable.tar.gz -C ~
-          cd ~/libsodium-stable
-          ./configure
-          make -j2 && make check
-          sudo make install
-          cd -
-
-      # cache secp256K1
-      - name: cache libsecp256k1
-        id: libsecp256k1
-        uses: actions/cache@v2
-        with:
-          path: ~/secp256k1
-          key: libsecp256k1
-
-      # install libsecp256k1 with cache
-      - name: Install cache libsecp256k1
-        if: steps.libsecp256k1.outputs.cache-hit == 'true'
-        run: |
-          cd ~/secp256k1
-          ./autogen.sh
-          ./configure --enable-module-schnorrsig --enable-experimental
-          make
-          sudo make install
-          cd -
-
-      # download & install secp256k1
-      - name: Install libsecp256k1
-        if: steps.libsecp256k1.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/bitcoin-core/secp256k1 ~/secp256k1
-          cd ~/secp256k1
-          git checkout ac83be33
-          ./autogen.sh
-          ./configure --enable-module-schnorrsig --enable-experimental
-          make
-          sudo make install
-          cd -
-
-      # set up environment variables
-      - name: Setup environment variables
-        run: |
-          echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
-
-      - uses: haskell/actions/setup@v2
-        id: setuphaskell
-        with:
-          ghc-version: '8.10' # Resolves to the latest point release of GHC 8.10
-          cabal-version: '3.6.0.0' # Exact version of Cabal
-
-      - name: Cache .cabal
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.setuphaskell.outputs.cabal-store }}
-          key: cabal-${{ hashFiles('cabal.project') }}
-
-      - name: Set up cabal.project.local
-        run: |
-          echo "package cardano-crypto-praos" > cabal.project.local
-          echo "  flags: -external-libsodium-vrf" >> cabal.project.local
-
-      - name: Build dependencies for integration test
-        run: |
-          cabal update
           cabal install -j cardano-node cardano-cli --overwrite-policy=always
           cabal install -j convex-wallet --overwrite-policy=always
-          echo "/home/runner/.cabal/bin" >> $GITHUB_PATH
-
-      - name: build & test
-        run: |
-          cabal build -j all
-          cabal test all
-          cabal haddock -j all
-
+      - name: Test all
+        run: cabal test all


### PR DESCRIPTION
Following up https://github.com/j-mueller/sc-tools/pull/102#issuecomment-1862829972 here is the PR that:
- keeps only one workflow but different jobs
- adds documentation building into the CI
- adds some parallelization in 3 jobs (testing, building, documentation building)
- factorizes common logic in 2 composite actions

I went a bit further the scope you defined but I think this approach should optimize the pipeline


Here is the outcome:
- no cache (44mins)
https://github.com/albertodvp/sc-tools/actions/runs/7293690204
- cache hit: libsodium, libsecp256k1, dependencies (14mins)
https://github.com/albertodvp/sc-tools/actions/runs/7293491807


Let me know what you think of this approach and/or if you have any suggestions :relaxed: