### PR TITLE
Fixing minimum UTxO value computation (node-1.35.4)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deleted spurious `runQuery'` log messages
 - The constraints for most of the functions in `Convex.CoinSelection` have changed from `MonadFail m` to `MonadError BalanceTxError m`, allowing for better error handling
 - Relaxed the `MonadError` instance of `MonadBlockchainCardanoNodeT` by removing the `MonadError e m` constraint; fixed the implementation of `catchError`
+- `Convex.BuildTx`: Ensure that at least 3 Ada is present when computing minimum UTxO value in `minAdaDeposit`.
 
 ### Added
 

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -358,10 +358,11 @@ setMinAdaDeposit params txOut =
 
 minAdaDeposit :: CLedger.PParams (C.ShelleyLedgerEra C.BabbageEra) -> C.TxOut C.CtxTx C.BabbageEra -> C.Quantity
 minAdaDeposit params txOut =
-  let txo = txOut
-              -- set the Ada value to a dummy amount to ensure that it is not 0 (if it was 0, the size of the output
-              -- would be smaller, causing 'calculateMinimumUTxO' to compute an amount that is a little too small)
-              & over (L._TxOut . _2 . L._TxOutValue . L._Value . at C.AdaAssetId) (maybe (Just $ C.Quantity 3_000_000) Just)
+  let minAdaValue = C.Quantity 3_000_000
+      txo = txOut
+            -- set the Ada value to a dummy amount to ensure that it is not 0 (if it was 0, the size of the output
+            -- would be smaller, causing 'calculateMinimumUTxO' to compute an amount that is a little too small)
+            & over (L._TxOut . _2 . L._TxOutValue . L._Value . at C.AdaAssetId) (maybe (Just minAdaValue) (Just . max minAdaValue))
   in fromMaybe (C.Quantity 0) $ do
         k <- either (const Nothing) pure (CC.calculateMinimumUTxO txo params)
         C.Lovelace l <- C.valueToLovelace k


### PR DESCRIPTION
- [x] Ensure that there is at least 3 Ada present when computing the minimum UTxO value in function `minAdaDeposit`