### PR TITLE
Update to ghc@9.6.3, cardano-node@8.7.2, cardano-api@8.36.1.1

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -5,6 +5,10 @@ on:
     tags: [ "*.*.*" ]
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,93 +19,29 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsystemd-dev
 
-      # cache libsodium
-      - name: cache libsodium-1.0.18
-        id: libsodium
-        uses: actions/cache@v2
-        with:
-          path: ~/libsodium-stable
-          key: ${{ runner.os }}-libsodium-1.0.18
+      - name: Install system dependencies
+        uses: input-output-hk/actions/base@latest
 
-      # install libsodium with cache
-      - name: Install cache libsodium-1.0.18
-        if: steps.libsodium.outputs.cache-hit == 'true'
-        run: cd ~/libsodium-stable && ./configure && make -j2 && sudo make install
-
-      # download & install libsodium without cache
-      - name: Install libsodium
-        if: steps.libsodium.outputs.cache-hit != 'true'
-        run: |
-          wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
-          tar -xvzf libsodium-1.0.18-stable.tar.gz -C ~
-          cd ~/libsodium-stable
-          ./configure
-          make -j2 && make check
-          sudo make install
-          cd -
-
-      # cache secp256K1
-      - name: cache libsecp256k1
-        id: libsecp256k1
-        uses: actions/cache@v2
-        with:
-          path: ~/secp256k1
-          key: libsecp256k1
-
-      # install libsecp256k1 with cache
-      - name: Install cache libsecp256k1
-        if: steps.libsecp256k1.outputs.cache-hit == 'true'
-        run: |
-          cd ~/secp256k1
-          ./autogen.sh
-          ./configure --enable-module-schnorrsig --enable-experimental
-          make
-          sudo make install
-          cd -
-
-      # download & install secp256k1
-      - name: Install libsecp256k1
-        if: steps.libsecp256k1.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/bitcoin-core/secp256k1 ~/secp256k1
-          cd ~/secp256k1
-          git checkout ac83be33
-          ./autogen.sh
-          ./configure --enable-module-schnorrsig --enable-experimental
-          make
-          sudo make install
-          cd -
-
-      # set up environment variables
-      - name: Setup environment variables
-        run: |
-          echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
 
       - uses: haskell-actions/setup@v2
-        id: setuphaskell
+        id: cabal-setup
         with:
-          ghc-version: '9.2.8'
+          ghc-version: '9.6.3'
           cabal-version: '3.10.1.0'
+
+      - uses: actions/checkout@v4
 
       - name: Cache .cabal
         uses: actions/cache@v3
         with:
-          path: ${{ steps.setuphaskell.outputs.cabal-store }}
+          path: ${{ steps.cabal-setup.outputs.cabal-store }}
           key: cabal-${{ hashFiles('cabal.project') }}
-
-      - name: Set up cabal.project.local
-        run: |
-          echo "package cardano-crypto-praos" > cabal.project.local
-          echo "  flags: -external-libsodium-vrf" >> cabal.project.local
 
       - name: Build dependencies for integration test
         run: |
           cabal update
-          cabal install -j cardano-node-8.1.1 --overwrite-policy=always
-          cabal install -j cardano-cli-8.4.0.0 --overwrite-policy=always
+          cabal install -j cardano-node-8.7.2 --overwrite-policy=always
+          cabal install -j cardano-cli-8.17.0.0 --overwrite-policy=always
           cabal install -j convex-wallet --overwrite-policy=always
           echo "/home/runner/.cabal/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -16,87 +16,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsystemd-dev
 
-      # cache libsodium
-      - name: cache libsodium-1.0.18
-        id: libsodium
-        uses: actions/cache@v2
-        with:
-          path: ~/libsodium-stable
-          key: ${{ runner.os }}-libsodium-1.0.18
+      - name: Install system dependencies
+        uses: input-output-hk/actions/base@latest
 
-      # install libsodium with cache
-      - name: Install cache libsodium-1.0.18
-        if: steps.libsodium.outputs.cache-hit == 'true'
-        run: cd ~/libsodium-stable && ./configure && make -j2 && sudo make install
-
-      # download & install libsodium without cache
-      - name: Install libsodium
-        if: steps.libsodium.outputs.cache-hit != 'true'
-        run: |
-          wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
-          tar -xvzf libsodium-1.0.18-stable.tar.gz -C ~
-          cd ~/libsodium-stable
-          ./configure
-          make -j2 && make check
-          sudo make install
-          cd -
-
-      # cache secp256K1
-      - name: cache libsecp256k1
-        id: libsecp256k1
-        uses: actions/cache@v2
-        with:
-          path: ~/secp256k1
-          key: libsecp256k1
-
-      # install libsecp256k1 with cache
-      - name: Install cache libsecp256k1
-        if: steps.libsecp256k1.outputs.cache-hit == 'true'
-        run: |
-          cd ~/secp256k1
-          ./autogen.sh
-          ./configure --enable-module-schnorrsig --enable-experimental
-          make
-          sudo make install
-          cd -
-
-      # download & install secp256k1
-      - name: Install libsecp256k1
-        if: steps.libsecp256k1.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/bitcoin-core/secp256k1 ~/secp256k1
-          cd ~/secp256k1
-          git checkout ac83be33
-          ./autogen.sh
-          ./configure --enable-module-schnorrsig --enable-experimental
-          make
-          sudo make install
-          cd -
-
-      # set up environment variables
-      - name: Setup environment variables
-        run: |
-          echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
 
       - uses: haskell-actions/setup@v2
-        id: setuphaskell
+        id: cabal-setup
         with:
-          ghc-version: '9.2.8'
+          ghc-version: '9.6.3'
           cabal-version: '3.10.1.0'
+
+      - uses: actions/checkout@v4
 
       - name: Cache .cabal
         uses: actions/cache@v3
         with:
-          path: ${{ steps.setuphaskell.outputs.cabal-store }}
+          path: ${{ steps.cabal-setup.outputs.cabal-store }}
           key: cabal-haddocks-${{ hashFiles('cabal.project') }}
-
-      - name: Set up cabal.project.local
-        run: |
-          echo "package cardano-crypto-praos" > cabal.project.local
-          echo "  flags: -external-libsodium-vrf" >> cabal.project.local
 
       - name: Build haddocks
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,9 +1,9 @@
 
 -- Custom repository for cardano haskell packages, see
--- https://github.com/input-output-hk/cardano-haskell-packages
+-- https://github.com/IntersectMBO/cardano-haskell-packages
 -- for more information.
 repository cardano-haskell-packages
-  url: https://input-output-hk.github.io/cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
   secure: True
   root-keys:
     3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
@@ -14,11 +14,14 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2023-07-22T22:41:49Z
-  , cardano-haskell-packages 2023-07-26T01:36:26Z
+  , hackage.haskell.org 2023-11-20T23:52:53Z
+  , cardano-haskell-packages 2023-12-08T09:30:26Z
 
+with-compiler: ghc-9.6.3
 
-with-compiler: ghc-9.2.8
+constraints:
+  cardano-api == 8.36.1.1,
+  cardano-node == 8.7.2
 
 packages:
   src/base
@@ -27,10 +30,3 @@ packages:
   src/mockchain
   src/coin-selection
   src/devnet
-
--- https://github.com/obsidiansystems/dependent-sum-template/issues/5
--- requires cabal 3.10
-if impl(ghc >= 9.2)
-  constraints :
-      dependent-sum-template < 0.1.2
-

--- a/src/base/convex-base.cabal
+++ b/src/base/convex-base.cabal
@@ -54,7 +54,7 @@ library
       either-result
       
     build-depends:
-      cardano-api == 8.8.0.0,
+      cardano-api,
       cardano-ledger-core,
       cardano-crypto-wrapper,
 
@@ -73,4 +73,5 @@ library
       serialise,
       bytestring,
       dlist,
-      either-result
+      either-result,
+      strict-sop-core

--- a/src/base/lib/Convex/PlutusLedger.hs
+++ b/src/base/lib/Convex/PlutusLedger.hs
@@ -218,7 +218,7 @@ unTransPOSIXTime :: PV1.POSIXTime -> POSIXTime
 unTransPOSIXTime (PV1.POSIXTime pt) = realToFrac @Rational $ fromIntegral pt / 1000
 
 unTransTxOutValue :: PV1.Value -> Either C.SerialiseAsRawBytesError (C.TxOutValue C.BabbageEra)
-unTransTxOutValue value = C.TxOutValue C.MultiAssetInBabbageEra <$> unTransValue value
+unTransTxOutValue value = C.TxOutValueShelleyBased C.ShelleyBasedEraBabbage . C.toMaryValue <$> unTransValue value
 
 unTransValue :: PV1.Value -> Either C.SerialiseAsRawBytesError C.Value
 unTransValue =
@@ -247,7 +247,7 @@ unTransScriptDataHash (P.DatumHash bs) =
   C.deserialiseFromRawBytes (C.AsHash C.AsScriptData) (PlutusTx.fromBuiltin bs)
 
 unTransTxOutDatumHash :: P.DatumHash -> Either C.SerialiseAsRawBytesError (C.TxOutDatum ctx C.BabbageEra)
-unTransTxOutDatumHash datumHash = C.TxOutDatumHash C.ScriptDataInBabbageEra <$> unTransScriptDataHash datumHash
+unTransTxOutDatumHash datumHash = C.TxOutDatumHash C.AlonzoEraOnwardsBabbage <$> unTransScriptDataHash datumHash
 
 _Interval :: Iso' (Interval a) (LowerBound a, UpperBound a)
 _Interval = iso from to where

--- a/src/base/lib/Convex/Scripts.hs
+++ b/src/base/lib/Convex/Scripts.hs
@@ -14,16 +14,16 @@ module Convex.Scripts(
 
 ) where
 
-import           Cardano.Api                        (PlutusScript)
-import qualified Cardano.Api.Shelley                as C
-import           Cardano.Ledger.Alonzo.Scripts.Data (Data (..))
-import           Codec.Serialise                    (serialise)
-import           Data.ByteString.Lazy               (toStrict)
-import           Data.ByteString.Short              (toShort)
-import           Ouroboros.Consensus.Shelley.Eras   (StandardBabbage)
-import           PlutusLedgerApi.Common             (serialiseCompiledCode)
-import qualified PlutusLedgerApi.V1                 as PV1
-import           PlutusTx.Code                      (CompiledCode)
+import           Cardano.Api                      (PlutusScript)
+import qualified Cardano.Api.Shelley              as C
+import           Cardano.Ledger.Plutus.Data       (Data (..))
+import           Codec.Serialise                  (serialise)
+import           Data.ByteString.Lazy             (toStrict)
+import           Data.ByteString.Short            (toShort)
+import           Ouroboros.Consensus.Shelley.Eras (StandardBabbage)
+import           PlutusLedgerApi.Common           (serialiseCompiledCode)
+import qualified PlutusLedgerApi.V1               as PV1
+import           PlutusTx.Code                    (CompiledCode)
 
 {-| Get the 'PlutusScript' of a 'CompiledCode'
 -}

--- a/src/coin-selection/convex-coin-selection.cabal
+++ b/src/coin-selection/convex-coin-selection.cabal
@@ -82,6 +82,5 @@ test-suite convex-coin-selection-test
     containers,
     plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
     plutus-ledger-api,
-    cardano-ledger-core,
     mtl,
     transformers

--- a/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
@@ -67,7 +67,7 @@ payToOperator' :: (MonadMockchain m, MonadError BalanceTxError m) => Tracer m Tx
 payToOperator' dbg value wFrom Operator{oPaymentKey} = do
   p <- queryProtocolParameters
   let addr =
-        C.makeShelleyAddressInEra Defaults.networkId
+        C.makeShelleyAddressInEra C.ShelleyBasedEraBabbage Defaults.networkId
         (C.PaymentCredentialByKey $ C.verificationKeyHash $ verificationKey oPaymentKey)
         C.NoStakeAddress
       tx = execBuildTx' $ payToAddress addr value >> setMinAdaDepositAll p

--- a/src/devnet/config/devnet/genesis-conway.json
+++ b/src/devnet/config/devnet/genesis-conway.json
@@ -1,4 +1,39 @@
 {
-    "genDelegs": {}
+  "poolVotingThresholds": {
+    "pvtCommitteeNormal": 0,
+    "pvtCommitteeNoConfidence": 0,
+    "pvtHardForkInitiation": 0,
+    "pvtMotionNoConfidence": 0
+  },
+  "dRepVotingThresholds": {
+    "dvtMotionNoConfidence": 0,
+    "dvtCommitteeNormal": 0,
+    "dvtCommitteeNoConfidence": 0,
+    "dvtUpdateToConstitution": 0,
+    "dvtHardForkInitiation": 0,
+    "dvtPPNetworkGroup": 0,
+    "dvtPPEconomicGroup": 0,
+    "dvtPPTechnicalGroup": 0,
+    "dvtPPGovGroup": 0,
+    "dvtTreasuryWithdrawal": 0
+  },
+  "committeeMinSize": 0,
+  "committeeMaxTermLength": 0,
+  "govActionLifetime": 0,
+  "govActionDeposit": 0,
+  "dRepDeposit": 0,
+  "dRepActivity": 0,
+  "constitution": {
+    "anchor": {
+      "url": "",
+      "dataHash": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  "committee": {
+    "members": {
+      "keyHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 1,
+      "scriptHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 2
+    },
+    "quorum": 0.5
   }
-  
+}

--- a/src/devnet/lib/Convex/Devnet/CardanoNode.hs
+++ b/src/devnet/lib/Convex/Devnet/CardanoNode.hs
@@ -26,8 +26,7 @@ module Convex.Devnet.CardanoNode(
   withCardanoNodeDevnetConfig
 ) where
 
-import           Cardano.Api                      (CardanoMode, Env,
-                                                   LocalNodeConnectInfo,
+import           Cardano.Api                      (Env, LocalNodeConnectInfo,
                                                    NetworkId)
 import qualified Cardano.Api                      as C
 import           Cardano.Ledger.Alonzo.Genesis    (AlonzoGenesis)
@@ -86,7 +85,7 @@ data RunningNode = RunningNode
   { rnNodeSocket     :: FilePath -- ^ Cardano node socket
   , rnNetworkId      :: NetworkId -- ^ Network ID used by the cardano node
   , rnNodeConfigFile :: FilePath -- ^ Cardano node config file (JSON)
-  , rnConnectInfo    :: (LocalNodeConnectInfo CardanoMode, Env) -- ^ Connection info for node queries
+  , rnConnectInfo    :: (LocalNodeConnectInfo, Env) -- ^ Connection info for node queries
   }
 
 -- | Configuration parameters for a single node devnet

--- a/src/devnet/test/Spec.hs
+++ b/src/devnet/test/Spec.hs
@@ -43,7 +43,7 @@ main = do
 
 checkCardanoNode :: IO ()
 checkCardanoNode =
-  let expectedVersion = "8.1.1"
+  let expectedVersion = "8.7.2"
   in getCardanoNodeVersion >>= assertBool ("cardano-node version should be " <> expectedVersion) . isInfixOf expectedVersion
 
 startLocalNode :: IO ()
@@ -81,7 +81,7 @@ runWalletServer =
 
 changeMaxTxSize :: IO ()
 changeMaxTxSize =
-  let getMaxTxSize = fmap (C.protocolParamMaxTxSize . C.unbundleProtocolParams) . queryProtocolParameters . fst . rnConnectInfo in
+  let getMaxTxSize = fmap (C.protocolParamMaxTxSize . C.fromLedgerPParams C.ShelleyBasedEraBabbage) . queryProtocolParameters . fst . rnConnectInfo in
   showLogsOnFailure $ \tr -> do
     withTempDir "cardano-cluster" $ \tmp -> do
       standardTxSize <- withCardanoNodeDevnetConfig (contramap TLNode tr) tmp mempty getMaxTxSize

--- a/src/mockchain/convex-mockchain.cabal
+++ b/src/mockchain/convex-mockchain.cabal
@@ -46,7 +46,10 @@ library
       transformers,
       HUnit,
       QuickCheck,
-      bytestring
+      bytestring,
+      sop-extras,
+      strict-sop-core,
+      sop-core
 
     -- cardano dependencies
     build-depends:

--- a/src/mockchain/lib/Convex/NodeParams.hs
+++ b/src/mockchain/lib/Convex/NodeParams.hs
@@ -29,7 +29,6 @@ module Convex.NodeParams(
   poolPledgeInfluence,
   monetaryExpansion,
   treasuryCut,
-  uTxOCostPerWord,
   costModels,
   prices,
   maxTxExUnits,
@@ -40,9 +39,10 @@ module Convex.NodeParams(
   uTxOCostPerByte
 ) where
 
-import           Cardano.Api           (BabbageEra, BundledProtocolParameters)
-import           Cardano.Api.Shelley   (CardanoMode, EraHistory, NetworkId (..),
-                                        PoolId, ProtocolParameters (..))
+import           Cardano.Api           (BabbageEra)
+import           Cardano.Api.Shelley   (EraHistory, LedgerProtocolParameters,
+                                        NetworkId (..), PoolId,
+                                        ProtocolParameters (..))
 import           Cardano.Slotting.Time (SlotLength, SystemStart)
 import           Control.Lens.TH       (makeLensesFor)
 import           Data.Set              as Set (Set)
@@ -50,9 +50,9 @@ import           Data.Set              as Set (Set)
 data NodeParams =
   NodeParams
     { npNetworkId          :: NetworkId
-    , npProtocolParameters :: BundledProtocolParameters BabbageEra
+    , npProtocolParameters :: LedgerProtocolParameters BabbageEra
     , npSystemStart        :: SystemStart
-    , npEraHistory         :: EraHistory CardanoMode
+    , npEraHistory         :: EraHistory
     , npStakePools         :: Set PoolId
     , npSlotLength         :: SlotLength
     }

--- a/src/node-client/lib/Convex/NodeClient/Resuming.hs
+++ b/src/node-client/lib/Convex/NodeClient/Resuming.hs
@@ -5,10 +5,10 @@ module Convex.NodeClient.Resuming(
   ResumingFrom(..),
   resumingClient) where
 
-import           Cardano.Api                                          (ChainPoint (..),
+import           Cardano.Api                                          (BlockInMode,
+                                                                       ChainPoint (..),
                                                                        ChainTip (..))
-import           Convex.NodeClient.Types                              (ClientBlock,
-                                                                       PipelinedLedgerStateClient (..))
+import           Convex.NodeClient.Types                              (PipelinedLedgerStateClient (..))
 import           Network.TypedProtocol.Pipelined                      (N (Z))
 import qualified Ouroboros.Network.Protocol.ChainSync.ClientPipelined as CSP
 
@@ -29,7 +29,7 @@ resumingClient ::
   (ResumingFrom -> PipelinedLedgerStateClient) ->
   PipelinedLedgerStateClient
 resumingClient syncPoints f = PipelinedLedgerStateClient $ CSP.ChainSyncClientPipelined $ do
-  let initialise :: CSP.ClientPipelinedStIdle 'Z ClientBlock ChainPoint ChainTip IO ()
+  let initialise :: CSP.ClientPipelinedStIdle 'Z BlockInMode ChainPoint ChainTip IO ()
       initialise = CSP.SendMsgFindIntersect syncPoints $
         CSP.ClientPipelinedStIntersect {
           CSP.recvMsgIntersectFound    = \chainPoint srvTip -> do

--- a/src/wallet/lib/Convex/Wallet.hs
+++ b/src/wallet/lib/Convex/Wallet.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE ViewPatterns       #-}
 {-| Primitive wallet
 -}
@@ -80,20 +81,20 @@ shelleyPaymentCredential =
 {-| Sign the transaction body with the signing key and attach the signature
 to the transaction
 -}
-addSignature :: IsShelleyBasedEra era => SigningKey PaymentKey -> C.Tx era -> C.Tx era
+addSignature :: forall era. IsShelleyBasedEra era => SigningKey PaymentKey -> C.Tx era -> C.Tx era
 addSignature (C.WitnessPaymentKey -> key) tx =
   let C.Tx body wits = tx
-      wit = nub $ C.makeShelleyKeyWitness body key : wits
+      wit = nub $ C.makeShelleyKeyWitness (C.shelleyBasedEra @era) body key : wits
       stx = C.makeSignedTransaction wit body
   in stx
 
 {-| Sign the transaction body with the extended signing key and attach the signature
 to the transaction
 -}
-addSignatureExtended :: IsShelleyBasedEra era => SigningKey PaymentExtendedKey -> C.Tx era -> C.Tx era
+addSignatureExtended :: forall era. IsShelleyBasedEra era => SigningKey PaymentExtendedKey -> C.Tx era -> C.Tx era
 addSignatureExtended (C.WitnessPaymentExtendedKey -> key) tx =
   let C.Tx body wits = tx
-      wit = nub $ C.makeShelleyKeyWitness body key : wits
+      wit = nub $ C.makeShelleyKeyWitness (C.shelleyBasedEra @era) body key : wits
       stx = C.makeSignedTransaction wit body
   in stx
 
@@ -108,9 +109,9 @@ address :: NetworkId -> Wallet -> Address ShelleyAddr
 address networkId wallet =
   C.makeShelleyAddress networkId (paymentCredential wallet) C.NoStakeAddress
 
-addressInEra :: IsShelleyBasedEra era => NetworkId -> Wallet -> AddressInEra era
+addressInEra :: forall era. IsShelleyBasedEra era => NetworkId -> Wallet -> AddressInEra era
 addressInEra networkId wallet =
-  C.makeShelleyAddressInEra networkId (paymentCredential wallet) C.NoStakeAddress
+  C.makeShelleyAddressInEra (C.shelleyBasedEra @era) networkId (paymentCredential wallet) C.NoStakeAddress
 
 {-| The wallet's private key (serialised)
 -}

--- a/src/wallet/lib/Convex/Wallet/Cli.hs
+++ b/src/wallet/lib/Convex/Wallet/Cli.hs
@@ -77,7 +77,7 @@ generateSigningKey verificationKeyFile signingKeyFile = do
     C.writeFileTextEnvelope (C.File signingKeyFile) Nothing signingKey >>= either (error . show) pure
     C.writeFileTextEnvelope (C.File verificationKeyFile) Nothing (C.getVerificationKey signingKey) >>= either (error . show) pure
 
-showAddress :: (MonadLog m, MonadError C.InitialLedgerStateError m, MonadIO m) => Config -> OperatorConfigVerification -> m (C.LocalNodeConnectInfo C.CardanoMode)
+showAddress :: (MonadLog m, MonadError C.InitialLedgerStateError m, MonadIO m) => Config -> OperatorConfigVerification -> m C.LocalNodeConnectInfo
 showAddress Config{cardanoNodeConfigFile, cardanoNodeSocket} operatorConfig = do
   op <- liftIO (loadOperatorFilesVerification operatorConfig)
   (info_@C.LocalNodeConnectInfo{C.localNodeNetworkId}, _) <- loadConnectInfo cardanoNodeConfigFile cardanoNodeSocket

--- a/src/wallet/lib/Convex/Wallet/NodeClient/BalanceClient.hs
+++ b/src/wallet/lib/Convex/Wallet/NodeClient/BalanceClient.hs
@@ -9,7 +9,7 @@ module Convex.Wallet.NodeClient.BalanceClient(
   balanceClient
   ) where
 
-import           Cardano.Api                (BlockInMode, CardanoMode, Env)
+import           Cardano.Api                (BlockInMode, Env)
 import qualified Cardano.Api                as C
 import           Control.Concurrent.STM     (TVar, atomically, newTVarIO,
                                              writeTVar)
@@ -53,11 +53,11 @@ balanceClient logEnv ns clientEnv walletState wallet env =
 
 {-| Apply a new block
 -}
-applyBlock :: K.LogEnv -> K.Namespace -> BalanceClientEnv -> C.PaymentCredential -> CatchingUp -> (CatchingUp, UtxoSet C.CtxTx ()) -> BlockInMode CardanoMode -> IO (Maybe (CatchingUp, UtxoSet C.CtxTx ()))
+applyBlock :: K.LogEnv -> K.Namespace -> BalanceClientEnv -> C.PaymentCredential -> CatchingUp -> (CatchingUp, UtxoSet C.CtxTx ()) -> BlockInMode -> IO (Maybe (CatchingUp, UtxoSet C.CtxTx ()))
 applyBlock logEnv ns BalanceClientEnv{bceFile, bceState} wallet c (oldC, state) block = K.runKatipContextT logEnv () ns $ runMonadLogKatipT $ runMaybeT $ do
   let change = Utxos.extract_ (toShelleyPaymentCredential wallet) state block
       newUTxOs = apply state change
-      C.BlockInMode (C.getBlockHeader -> header) _ = block
+      C.BlockInMode _ (C.getBlockHeader -> header) = block
       newState = WalletState.walletState newUTxOs header
 
   when (not $ Utxos.null change) $ do


### PR DESCRIPTION
Major changes:

* The tx validity field of the `TxBody` type has been split up into two separate fields
* CHaP now located at intersect MBO repository
* `BundledProtocolParamters` type replaced by `LedgerProtocolParameters`
* `Convex.MockChain.ScriptContext` replaced by `Cardano.Ledger.Plutus.Evaluate.PlutusWithContext`