### PR TITLE
Considering withdrawals and certificates in mapTxScriptWitnesses

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relaxed the `MonadError` instance of `MonadBlockchainCardanoNodeT` by removing the `MonadError e m` constraint; fixed the implementation of `catchError`
 - `Convex.BuildTx`: Ensure that at least 3 Ada is present when computing minimum UTxO value in `minAdaDeposit`.
 - Fixed a bug in coin selection where the wallet's mixed inputs were not considered for a `TxBodyContent` with zero inputs
-- Considering withdrawals and certificats in `mapTxScriptWtinesses`.
+- Considering withdrawals and certificates in `mapTxScriptWtinesses`.
 - Function `substituteExecutionUnits` updated to trigger `TxBodyErrorAutoBalance` when witnesses are not found.
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relaxed the `MonadError` instance of `MonadBlockchainCardanoNodeT` by removing the `MonadError e m` constraint; fixed the implementation of `catchError`
 - `Convex.BuildTx`: Ensure that at least 3 Ada is present when computing minimum UTxO value in `minAdaDeposit`.
 - Fixed a bug in coin selection where the wallet's mixed inputs were not considered for a `TxBodyContent` with zero inputs
+- Considering withdrawals and certificats in `mapTxScriptWtinesses`.
+- Function `substituteExecutionUnits` updated to trigger `TxBodyErrorAutoBalance` when witnesses are not found.
 
 ### Added
 

--- a/src/coin-selection/lib/Convex/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection.hs
@@ -304,8 +304,8 @@ substituteExecutionUnits exUnitsMap =
       case Map.lookup idx exUnitsMap of
         Nothing ->
           Left $ C.TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap idx exUnitsMap
-        Just exunits -> Right $ C.PlutusScriptWitness langInEra version script
-                                            datum redeemer exunits
+        Just exunits -> Right $ C.PlutusScriptWitness langInEra version script datum redeemer exunits
+
 -- | same behaviour as in Cardano.Api.TxBody.
 mapTxScriptWitnesses
   :: (forall witctx. C.ScriptWitnessIndex
@@ -397,9 +397,8 @@ mapTxScriptWitnesses f txbodycontent@C.TxBodyContent {
               [ (stakecred, C.ScriptWitness ctx <$> witness')
                 -- The certs are indexed in list order
               | (ix, cert) <- zip [0..] certs
-              , stakecred  <- maybeToList (selectStakeCredential cert)
-              , C.ScriptWitness ctx witness
-                           <- maybeToList (Map.lookup stakecred witnesses)
+              , stakecred <- maybeToList (selectStakeCredential cert)
+              , C.ScriptWitness ctx witness <- maybeToList (Map.lookup stakecred witnesses)
               , let witness' = f (C.ScriptWitnessIndexCertificate ix) witness
               ]
       in C.TxCertificates supported certs . C.BuildTxWith . Map.fromList <$>
@@ -439,15 +438,17 @@ mapTxScriptWitnesses f txbodycontent@C.TxBodyContent {
             Right . C.TxMintValue supported value . C.BuildTxWith
               $ Map.fromList final
 
--- This relies on the TxId Ord instance being consistent with the
--- Ledger.TxId Ord instance via the toShelleyTxId conversion
--- This is checked by prop_ord_distributive_TxId
+{-| This relies on the TxId Ord instance being consistent with the
+Ledger.TxId Ord instance via the toShelleyTxId conversion.
+This is checked by prop_ord_distributive_TxId
+-}
 orderTxIns :: [(C.TxIn, v)] -> [(C.TxIn, v)]
 orderTxIns = List.sortBy (compare `on` fst)
 
--- This relies on the StakeAddress Ord instance being consistent with the
--- Shelley.RewardAcnt Ord instance via the toShelleyStakeAddr conversion
--- This is checked by prop_ord_distributive_StakeAddress
+{-| This relies on the StakeAddress Ord instance being consistent with the
+Shelley.RewardAcnt Ord instance via the toShelleyStakeAddr conversion.
+This is checked by prop_ord_distributive_StakeAddress
+-}
 orderStakeAddrs :: [(C.StakeAddress, x, v)] -> [(C.StakeAddress, x, v)]
 orderStakeAddrs = List.sortBy (compare `on` (\(k, _, _) -> k))
 


### PR DESCRIPTION
- [x] Update mapTxScriptWitnesses to consider withdrawals and certificates
- [x] Update `substituteExecutionUnits`  to trigger `TxBodyErrorAutoBalance` when witnesses are not found.
