### PR TITLE
Remove initial ledger state from runNodeClient

### DIFF
--- a/src/node-client/lib/Convex/NodeClient/Types.hs
+++ b/src/node-client/lib/Convex/NodeClient/Types.hs
@@ -26,7 +26,7 @@ import           Cardano.Api                                          (BlockInMo
                                                                        LocalNodeClientProtocols (..),
                                                                        LocalNodeClientProtocolsInMode,
                                                                        LocalNodeConnectInfo (..),
-                                                                       connectToLocalNode, LedgerState, initialLedgerState)
+                                                                       connectToLocalNode)
 import           Cardano.Slotting.Slot                                (WithOrigin (At, Origin))
 import           Control.Monad.IO.Class                               (MonadIO (..))
 import           Control.Monad.Trans.Class                            (lift)
@@ -44,12 +44,11 @@ newtype PipelinedLedgerStateClient =
 runNodeClient ::
   FilePath -- ^ Path to the cardano-node config file (e.g. <path to cardano-node project>/configuration/cardano/mainnet-config.json)
   -> FilePath -- ^ Path to local cardano-node socket. This is the path specified by the @--socket-path@ command line option when running the node.
-  -> (LocalNodeConnectInfo CardanoMode -> LedgerState -> Env -> IO PipelinedLedgerStateClient) -- ^ Client
+  -> (LocalNodeConnectInfo CardanoMode ->  Env -> IO PipelinedLedgerStateClient) -- ^ Client
   -> ExceptT InitialLedgerStateError IO () -- ^ Final state
 runNodeClient nodeConfigFilePath socketPath client = do
   (connectInfo, env) <- loadConnectInfo nodeConfigFilePath socketPath
-  ledgerState0 <- snd <$> initialLedgerState nodeConfigFilePath
-  c <- liftIO (client connectInfo ledgerState0 env)
+  c <- liftIO (client connectInfo env)
   lift $ connectToLocalNode connectInfo (protocols c)
 
 protocols :: PipelinedLedgerStateClient -> LocalNodeClientProtocolsInMode CardanoMode

--- a/src/wallet/lib/Convex/Wallet/Cli.hs
+++ b/src/wallet/lib/Convex/Wallet/Cli.hs
@@ -93,7 +93,7 @@ runWallet logEnv port Config{cardanoNodeConfigFile, cardanoNodeSocket, walletFil
   e <- liftIO (NC.balanceClientEnv walletFile initialState)
   logInfoS $ "Starting wallet server on port " <> show port
   _ <- liftIO $ forkIO (API.startServer (NC.bceState e) port)
-  let client _ _ env = do
+  let client _ env = do
         pure (NC.balanceClient logEnv "wallet" e initialState (operatorPaymentCredential op) env)
   result <- liftIO $ runExceptT (runNodeClient cardanoNodeConfigFile cardanoNodeSocket client)
   case result of


### PR DESCRIPTION
@j-mueller I think we should remove this part. I have not included the ledger state in this function in the back port version.