### PR TITLE
Use TxBuilder in coin selection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Function `substituteExecutionUnits` updated to trigger `TxBodyErrorAutoBalance` when witnesses are not found.
 * `MonadMockchain.sendTx` returns `Either` to allow the caller to handle submission failures
 * `MonadMockchain.resolveDatumHash` returns `HashableScriptData` instead of `ScriptData` to avoid re-hashing data values as much as possible
+* Coin selection uses `TxBuilder` instead of `TxBodyContent`
 
 ### Added
 

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -10,6 +10,7 @@
 module Convex.BuildTx(
   -- * Tx Builder
   TxBuilder(..),
+  liftTxBodyEndo,
   -- ** Looking at transaction inputs
   lookupIndexSpending,
   lookupIndexReference,
@@ -189,6 +190,10 @@ newtype TxBuilder = TxBuilder{ unTxBuilder :: TxBody -> TxBody -> TxBody }
 -}
 buildTx :: TxBuilder -> TxBody
 buildTx txb = buildTxWith txb L.emptyTx
+
+-- | The 'TxBuilder' that modifies the tx body without looking at the final result
+liftTxBodyEndo :: (TxBody -> TxBody) -> TxBuilder
+liftTxBodyEndo f = TxBuilder (const f)
 
 {-| Construct the final @TxBodyContent@ from the provided @TxBodyContent@
 -}

--- a/src/base/lib/Convex/Class.hs
+++ b/src/base/lib/Convex/Class.hs
@@ -46,7 +46,6 @@ import           Cardano.Api.Shelley                               (BabbageEra,
                                                                     NetworkId,
                                                                     PaymentCredential,
                                                                     PoolId,
-                                                                    HashableScriptData,
                                                                     ScriptData,
                                                                     SlotNo, Tx,
                                                                     TxId)
@@ -75,7 +74,8 @@ import           Convex.MonadLog                                   (MonadLog (..
                                                                     logWarnS)
 import           Convex.Utils                                      (posixTimeToSlotUnsafe,
                                                                     slotToUtcTime)
-import           Data.Aeson                                        (ToJSON, FromJSON)
+import           Data.Aeson                                        (FromJSON,
+                                                                    ToJSON)
 import           Data.Bifunctor                                    (Bifunctor (..))
 import           Data.Map                                          (Map)
 import qualified Data.Map                                          as Map

--- a/src/coin-selection/lib/Convex/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs              #-}
 {-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE MultiWayIf         #-}
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes         #-}
@@ -58,15 +59,15 @@ import           Cardano.Slotting.Time         (SystemStart)
 import           Control.Lens                  (_1, _2, _3, at, makeLensesFor,
                                                 over, preview, set, to,
                                                 traversed, view, (%~), (&),
-                                                (.~), (<>~), (?~), (^.), (^..),
-                                                (|>))
+                                                (<>~), (?~), (^.), (^..), (|>))
 import           Control.Monad                 (when)
 import           Control.Monad.Except          (MonadError (..))
 import           Control.Monad.Trans.Class     (MonadTrans (..))
 import           Control.Tracer                (Tracer, natTracer, traceWith)
-import           Convex.BuildTx                (addCollateral, buildTxWith,
+import           Convex.BuildTx                (TxBuilder, addCollateral,
                                                 execBuildTx, setMinAdaDeposit,
                                                 spendPublicKeyOutput)
+import qualified Convex.BuildTx                as BuildTx
 import           Convex.Class                  (MonadBlockchain (..))
 import qualified Convex.CardanoApi.Lenses      as L
 import           Convex.Utils                  (mapError)
@@ -495,7 +496,7 @@ balanceTx ::
   UtxoSet C.CtxUTxO a ->
 
   -- | The unbalanced transaction body
-  TxBodyContent BuildTx ERA ->
+  TxBuilder ->
 
   -- | The balanced transaction body and the balance changes (per address)
   m (C.BalancedTxBody ERA, BalanceChanges)
@@ -504,9 +505,9 @@ balanceTx dbg returnUTxO0 walletUtxo txb = do
   pools <- queryStakePools
   availableUTxOs <- checkCompatibilityLevel dbg txb walletUtxo
   -- compatibility level
-  let txb0 = txb & L.txProtocolParams .~ C.BuildTxWith (Just params)
+  let txb0 = txb <> (BuildTx.liftTxBodyEndo (set L.txProtocolParams (C.BuildTxWith (Just params))))
   -- TODO: Better error handling (better than 'fail')
-  otherInputs <- lookupTxIns (requiredTxIns txb)
+  otherInputs <- lookupTxIns (requiredTxIns $ BuildTx.buildTx txb)
   let combinedTxIns =
         let UTxO w = availableUTxOs
             UTxO o = otherInputs
@@ -524,8 +525,8 @@ balanceTx dbg returnUTxO0 walletUtxo txb = do
 
 -- | Check the compatibility level of the transaction body
 --   and remove any incompatible UTxOs from the UTxO set.
-checkCompatibilityLevel :: Monad m => Tracer m TxBalancingMessage -> TxBodyContent BuildTx ERA -> UtxoSet C.CtxUTxO a -> m (UTxO BabbageEra)
-checkCompatibilityLevel tr txB (UtxoSet w) = do
+checkCompatibilityLevel :: Monad m => Tracer m TxBalancingMessage -> TxBuilder -> UtxoSet C.CtxUTxO a -> m (UTxO BabbageEra)
+checkCompatibilityLevel tr (BuildTx.buildTx -> txB) (UtxoSet w) = do
   let compatibility = txCompatibility txB
       utxoIn = UTxO (fmap fst w)
       UTxO utxoOut = compatibleWith compatibility utxoIn
@@ -535,7 +536,7 @@ checkCompatibilityLevel tr txB (UtxoSet w) = do
 
 {-| Balance the transaction using the wallet's funds, then sign it.
 -}
-balanceForWallet :: (MonadBlockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> UtxoSet C.CtxUTxO a -> TxBodyContent BuildTx ERA -> m (C.Tx ERA, BalanceChanges)
+balanceForWallet :: (MonadBlockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> UtxoSet C.CtxUTxO a -> TxBuilder -> m (C.Tx ERA, BalanceChanges)
 balanceForWallet dbg wallet walletUtxo txb = do
   n <- networkId
   let walletAddress = Wallet.addressInEra n wallet
@@ -544,7 +545,7 @@ balanceForWallet dbg wallet walletUtxo txb = do
 
 {-| Balance the transaction using the wallet's funds and the provided return output, then sign it.
 -}
-balanceForWalletReturn :: (MonadBlockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> UtxoSet C.CtxUTxO a -> C.TxOut C.CtxTx C.BabbageEra -> TxBodyContent BuildTx ERA -> m (C.Tx ERA, BalanceChanges)
+balanceForWalletReturn :: (MonadBlockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> UtxoSet C.CtxUTxO a -> C.TxOut C.CtxTx C.BabbageEra -> TxBuilder -> m (C.Tx ERA, BalanceChanges)
 balanceForWalletReturn dbg wallet walletUtxo returnOutput txb = do
   first (signForWallet wallet) <$> balanceTx dbg returnOutput walletUtxo txb
 
@@ -559,29 +560,32 @@ signForWallet wallet (C.BalancedTxBody _ txbody _changeOutput _fee) =
 --   (we have to do this because 'C.evaluateTransactionBalance' fails on a tx body with
 --    no inputs)
 --   Throws an error if the transaction body has no inputs and the wallet UTxO set is empty.
-addOwnInput :: MonadError CoinSelectionError m => TxBodyContent BuildTx ERA -> UtxoSet ctx a -> m (TxBodyContent BuildTx ERA)
-addOwnInput body (Utxos.removeUtxos (spentTxIns body) -> UtxoSet{_utxos})
-  | not (List.null $ view L.txIns body) = pure body
-  | not (Map.null _utxos) =
-      -- Select ada-only outputs if possible
-      let availableUTxOs = List.sortOn (length . view (L._TxOut . _2 . L._TxOutValue . to C.valueToList) . fst . snd) (Map.toList _utxos)
-      in pure $ buildTxWith (execBuildTx (spendPublicKeyOutput (fst $ head availableUTxOs))) body
-  | otherwise = throwError NoWalletUTxOs
+addOwnInput :: MonadError CoinSelectionError m => TxBuilder -> UtxoSet ctx a -> m TxBuilder
+addOwnInput builder allUtxos =
+  let body = BuildTx.buildTx builder
+      UtxoSet{_utxos} = Utxos.removeUtxos (spentTxIns body) allUtxos
+  in  if | not (List.null $ view L.txIns body) -> pure builder
+         | not (Map.null _utxos) ->
+              -- Select ada-only outputs if possible
+              let availableUTxOs = List.sortOn (length . view (L._TxOut . _2 . L._TxOutValue . to C.valueToList) . fst . snd) (Map.toList _utxos)
+              in pure $ builder <> execBuildTx (spendPublicKeyOutput (fst $ head availableUTxOs))
+         | otherwise -> throwError NoWalletUTxOs
 
 -- | Add a collateral input. Throws a 'NoAdaOnlyUTxOsForCollateral' error if a collateral input is required,
 --   but no suitable input is provided in the wallet UTxO set.
-setCollateral :: MonadError CoinSelectionError m => TxBodyContent BuildTx ERA -> UtxoSet ctx a -> m (TxBodyContent BuildTx ERA)
-setCollateral body (Utxos.onlyAda -> UtxoSet{_utxos}) =
-  let noScripts = not (runsScripts body)
+setCollateral :: MonadError CoinSelectionError m => TxBuilder -> UtxoSet ctx a -> m TxBuilder
+setCollateral builder (Utxos.onlyAda -> UtxoSet{_utxos}) =
+  let body = BuildTx.buildTx builder
+      noScripts = not (runsScripts body)
       hasCollateral = not (view (L.txInsCollateral . L._TxInsCollateral . to List.null) body)
   in
     if noScripts || hasCollateral
-      then pure body -- no script witnesses in inputs.
+      then pure builder -- no script witnesses in inputs.
       else
         -- select the output with the largest amount of Ada
         case listToMaybe $ List.sortOn (Down . C.selectLovelace . view (L._TxOut . _2 . L._TxOutValue) . fst . snd) $ Map.toList _utxos of
           Nothing     -> throwError NoAdaOnlyUTxOsForCollateral
-          Just (k, _) -> pure $ buildTxWith (execBuildTx (addCollateral k)) body
+          Just (k, _) -> pure $ builder <> execBuildTx (addCollateral k)
 
 {-| Whether the transaction runs any plutus scripts
 -}
@@ -599,8 +603,9 @@ runsScripts body =
 * The amount of Ada provided by the transaction's inputs minus (the amount of Ada produced by the transaction's outputs plus the change output) is greater than zero
 * For all native tokens @t@, the amount of @t@ provided by the transaction's inputs minus (the amount of @t@ produced by the transaction's outputs plus the change output plus the delta of @t@ minted / burned) is equal to zero
 -}
-balancePositive :: MonadError CoinSelectionError m => Tracer m TxBalancingMessage -> Set PoolId -> C.LedgerProtocolParameters BabbageEra -> C.UTxO ERA -> C.TxOut C.CtxTx C.BabbageEra -> UtxoSet ctx a -> TxBodyContent BuildTx ERA -> m (TxBodyContent BuildTx ERA, C.TxOut C.CtxTx C.BabbageEra)
-balancePositive dbg poolIds ledgerPPs utxo_ returnUTxO0 walletUtxo txBodyContent0 = do
+balancePositive :: MonadError CoinSelectionError m => Tracer m TxBalancingMessage -> Set PoolId -> C.LedgerProtocolParameters BabbageEra -> C.UTxO ERA -> C.TxOut C.CtxTx C.BabbageEra -> UtxoSet ctx a -> TxBuilder -> m (TxBuilder, C.TxOut C.CtxTx C.BabbageEra)
+balancePositive dbg poolIds ledgerPPs utxo_ returnUTxO0 walletUtxo txBuilder0 = do
+  let txBodyContent0 = BuildTx.buildTx txBuilder0
   txb <- either (throwError . bodyError) pure (C.createAndValidateTransactionBody C.ShelleyBasedEraBabbage txBodyContent0)
   let bal = C.evaluateTransactionBalance C.ShelleyBasedEraBabbage (C.unLedgerProtocolParameters ledgerPPs) poolIds mempty mempty utxo_ txb & view L._TxOutValue
       available = Utxos.removeUtxos (spentTxIns txBodyContent0) walletUtxo
@@ -616,12 +621,12 @@ balancePositive dbg poolIds ledgerPPs utxo_ returnUTxO0 walletUtxo txBodyContent
     { availableBalance   = Utxos.totalBalance available
     , transactionBalance = balance
     }
-  (txBodyContent1, additionalBalance) <- addInputsForAssets dbg balance available txBodyContent0
+  (txBuilder1, additionalBalance) <- addInputsForAssets dbg balance available txBuilder0
 
   let bal0 = balance <> additionalBalance
   let (returnUTxO1, _deposit) = addOutputForNonAdaAssets ledgerPPs returnUTxO0 bal0
 
-  pure (txBodyContent1, returnUTxO1)
+  pure (txBuilder1, returnUTxO1)
 
 {-| Examine the negative part of the transaction balance and select inputs from
 the wallet's UTXO set to cover the assets required by it. If there are no
@@ -632,18 +637,18 @@ addInputsForAssets ::
   Tracer m TxBalancingMessage ->
   C.Value -> -- ^ The balance of the transaction
   UtxoSet ctx a -> -- ^ UTxOs that we can spend to cover the negative part of the balance
-  TxBodyContent BuildTx ERA -> -- ^ Transaction body
-  m (TxBodyContent BuildTx ERA, C.Value) -- ^ Transaction body with additional inputs and the total value of the additional inputs
-addInputsForAssets dbg txBal availableUtxo txBodyContent
-  | null (fst $ splitValue txBal) = do
-      traceWith dbg NoAssetsMissing
-      return (txBodyContent, mempty)
-  | otherwise = do
-      let missingAssets = fmap (second abs) $ fst $ splitValue txBal
-      traceWith dbg (MissingAssets $ C.valueFromList missingAssets)
-      case Wallet.selectMixedInputsCovering availableUtxo missingAssets of
-        Nothing -> throwError (NotEnoughMixedOutputsFor (C.valueFromList missingAssets) (Utxos.totalBalance availableUtxo) txBal)
-        Just (total, ins) -> pure (txBodyContent & over L.txIns (<> fmap spendPubKeyTxIn ins), total)
+  TxBuilder -> -- ^ Transaction body
+  m (TxBuilder, C.Value) -- ^ Transaction body with additional inputs and the total value of the additional inputs
+addInputsForAssets dbg txBal availableUtxo txBuilder =
+  if | null (fst $ splitValue txBal) -> do
+        traceWith dbg NoAssetsMissing
+        return (txBuilder, mempty)
+     | otherwise -> do
+        let missingAssets = fmap (second abs) $ fst $ splitValue txBal
+        traceWith dbg (MissingAssets $ C.valueFromList missingAssets)
+        case Wallet.selectMixedInputsCovering availableUtxo missingAssets of
+          Nothing -> throwError (NotEnoughMixedOutputsFor (C.valueFromList missingAssets) (Utxos.totalBalance availableUtxo) txBal)
+          Just (total, ins) -> pure (txBuilder <> BuildTx.liftTxBodyEndo (over L.txIns (<> fmap spendPubKeyTxIn ins)), total)
 
 {-| Examine the positive part of the transaction balance and add any non-Ada assets it contains
 to the provided change output. If the positive part only contains Ada then the
@@ -677,9 +682,9 @@ prepCSInputs ::
   => TransactionSignatureCount
   -> C.TxOut C.CtxTx C.BabbageEra -- ^ Change address
   -> C.UTxO ERA -- ^ UTxOs that may be used for balancing
-  -> C.TxBodyContent C.BuildTx C.BabbageEra -- ^ Unbalanced transaction body
+  -> TxBuilder -- ^ Unbalanced transaction body
   -> m CSInputs -- ^ Inputs for coin balancing
-prepCSInputs sigCount csiChangeAddress csiUtxo csiTxBody = do
+prepCSInputs sigCount csiChangeAddress csiUtxo (BuildTx.buildTx -> csiTxBody) = do
   CSInputs
     <$> pure csiUtxo
     <*> pure csiTxBody
@@ -708,8 +713,9 @@ keyWitnesses (requiredTxIns -> inputs) = do
 -- | The number of signatures required to spend the transaction's inputs
 --   and to satisfy the "extra key witnesses" constraint
 --   and required for certification.
-requiredSignatureCount :: MonadBlockchain m => C.TxBodyContent C.BuildTx C.BabbageEra -> m TransactionSignatureCount
-requiredSignatureCount content = do
+requiredSignatureCount :: MonadBlockchain m => TxBuilder -> m TransactionSignatureCount
+requiredSignatureCount txBuilder = do
+  let content = BuildTx.buildTx txBuilder
   keyWits <- keyWitnesses content
   let hsh (C.PaymentKeyHash h) = h
       extraSigs = view (L.txExtraKeyWits . L._TxExtraKeyWitnesses) content

--- a/src/coin-selection/lib/Convex/CoinSelection/Class.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection/Class.hs
@@ -12,8 +12,7 @@ module Convex.CoinSelection.Class(
   runTracingBalancingT
 ) where
 
-import           Cardano.Api.Shelley              (AddressInEra, BabbageEra,
-                                                   BuildTx, TxBodyContent)
+import           Cardano.Api.Shelley              (AddressInEra, BabbageEra)
 import qualified Cardano.Api.Shelley              as C
 import           Control.Monad.Catch              (MonadCatch, MonadMask,
                                                    MonadThrow)
@@ -25,14 +24,15 @@ import           Control.Monad.Trans.Class        (MonadTrans (..))
 import qualified Control.Monad.Trans.State        as StrictState
 import qualified Control.Monad.Trans.State.Strict as LazyState
 import           Control.Tracer                   (Tracer, natTracer)
+import           Convex.BuildTx                   (TxBuilder)
 import           Convex.Class                     (MonadBlockchain (..),
                                                    MonadMockchain (..))
-import           Convex.Query                     (MonadUtxoQuery(utxosByPaymentCredentials))
 import           Convex.CoinSelection             (BalanceTxError,
                                                    TxBalancingMessage)
 import qualified Convex.CoinSelection
 import           Convex.CardanoApi.Lenses         (emptyTxOut)
 import           Convex.MonadLog                  (MonadLog, MonadLogIgnoreT)
+import           Convex.Query                     (MonadUtxoQuery (utxosByPaymentCredentials))
 import           Convex.Utxos                     (BalanceChanges (..),
                                                    UtxoSet (..))
 
@@ -60,7 +60,7 @@ class Monad m => MonadBalance m where
     UtxoSet C.CtxUTxO a ->
 
     -- | The unbalanced transaction body
-    TxBodyContent BuildTx BabbageEra ->
+    TxBuilder ->
 
     -- | The balanced transaction body and the balance changes (per address)
     m (Either BalanceTxError (C.BalancedTxBody BabbageEra, BalanceChanges))

--- a/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
@@ -13,12 +13,11 @@ module Convex.MockChain.CoinSelection(
   payToOperator'
 ) where
 
-import           Cardano.Api.Shelley       (BabbageEra, BuildTx, TxBodyContent,
-                                            Value)
+import           Cardano.Api.Shelley       (Value)
 import qualified Cardano.Api.Shelley       as C
 import           Control.Monad.Except      (MonadError)
 import           Control.Tracer            (Tracer)
-import           Convex.BuildTx            (buildTx, execBuildTx, execBuildTx',
+import           Convex.BuildTx            (TxBuilder, execBuildTx,
                                             payToAddress, setMinAdaDepositAll)
 import           Convex.Class              (MonadBlockchain (..),
                                             MonadMockchain, SendTxFailed (..))
@@ -35,7 +34,7 @@ import           Data.Functor              (($>))
 {-| Balance and submit a transaction using the wallet's UTXOs
 on the mockchain, using the default network ID
 -}
-balanceAndSubmit :: (MonadMockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> TxBodyContent BuildTx BabbageEra -> m (Either SendTxFailed (C.Tx CoinSelection.ERA))
+balanceAndSubmit :: (MonadMockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> TxBuilder -> m (Either SendTxFailed (C.Tx CoinSelection.ERA))
 balanceAndSubmit dbg wallet tx = do
   n <- networkId
   let walletAddress = Wallet.addressInEra n wallet
@@ -46,7 +45,7 @@ balanceAndSubmit dbg wallet tx = do
 on the mockchain, using the default network ID. Fail if the
 transaction is not accepted by the node.
 -}
-tryBalanceAndSubmit :: (MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => Tracer m TxBalancingMessage -> Wallet -> TxBodyContent BuildTx BabbageEra -> m (C.Tx CoinSelection.ERA)
+tryBalanceAndSubmit :: (MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => Tracer m TxBalancingMessage -> Wallet -> TxBuilder -> m (C.Tx CoinSelection.ERA)
 tryBalanceAndSubmit dbg wallet tx = do
   n <- networkId
   let walletAddress = Wallet.addressInEra n wallet
@@ -56,7 +55,7 @@ tryBalanceAndSubmit dbg wallet tx = do
 {-| Balance and submit a transaction using the given return output and the wallet's UTXOs
 on the mockchain, using the default network ID
 -}
-balanceAndSubmitReturn :: (MonadMockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> C.TxOut C.CtxTx C.BabbageEra -> TxBodyContent BuildTx BabbageEra -> m (Either SendTxFailed (C.Tx CoinSelection.ERA))
+balanceAndSubmitReturn :: (MonadMockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> C.TxOut C.CtxTx C.BabbageEra -> TxBuilder -> m (Either SendTxFailed (C.Tx CoinSelection.ERA))
 balanceAndSubmitReturn dbg wallet returnOutput tx = do
   u <- MockChain.walletUtxo wallet
   (tx', _) <- CoinSelection.balanceForWalletReturn dbg wallet u returnOutput tx
@@ -67,7 +66,7 @@ balanceAndSubmitReturn dbg wallet returnOutput tx = do
 -}
 paymentTo :: (MonadMockchain m, MonadError BalanceTxError m) => Wallet -> Wallet -> m (Either SendTxFailed (C.Tx CoinSelection.ERA))
 paymentTo wFrom wTo = do
-  let tx = buildTx $ execBuildTx (payToAddress (Wallet.addressInEra Defaults.networkId wTo) (C.lovelaceToValue 10_000_000))
+  let tx = execBuildTx (payToAddress (Wallet.addressInEra Defaults.networkId wTo) (C.lovelaceToValue 10_000_000))
   balanceAndSubmit mempty wFrom tx
 
 {-| Pay 100 Ada from one of the seed addresses to an @Operator@
@@ -84,5 +83,5 @@ payToOperator' dbg value wFrom Operator{oPaymentKey} = do
         C.makeShelleyAddressInEra C.ShelleyBasedEraBabbage Defaults.networkId
         (C.PaymentCredentialByKey $ C.verificationKeyHash $ verificationKey oPaymentKey)
         C.NoStakeAddress
-      tx = execBuildTx' $ payToAddress addr value >> setMinAdaDepositAll p
+      tx = execBuildTx (payToAddress addr value >> setMinAdaDepositAll p)
   balanceAndSubmit dbg wFrom tx

--- a/src/coin-selection/test/Spec.hs
+++ b/src/coin-selection/test/Spec.hs
@@ -18,7 +18,7 @@ import           Control.Monad.IO.Class         (MonadIO (..))
 import           Control.Monad.State.Strict     (execStateT, modify)
 import           Control.Monad.Trans.Class      (MonadTrans (..))
 import           Convex.BuildTx                 (BuildTxT, addRequiredSignature,
-                                                 assetValue, execBuildTx',
+                                                 assetValue, execBuildTx,
                                                  execBuildTxT, mintPlutusV1,
                                                  payToAddress,
                                                  payToAddressTxOut,
@@ -47,7 +47,8 @@ import qualified Convex.MockChain.Defaults      as Defaults
 import qualified Convex.MockChain.Gen           as Gen
 import           Convex.MockChain.Utils         (mockchainSucceeds,
                                                  runMockchainProp)
-import           Convex.NodeParams              (maxTxSize, ledgerProtocolParameters)
+import           Convex.NodeParams              (ledgerProtocolParameters,
+                                                 maxTxSize)
 import           Convex.Query                   (balancePaymentCredentials)
 import           Convex.Utils                   (failOnError)
 import qualified Convex.Utxos                   as Utxos
@@ -125,31 +126,31 @@ mintingScript = C.examplePlutusScriptAlwaysSucceeds C.WitCtxMint
 
 payToPlutusScript :: (MonadFail m, MonadError BalanceTxError m, MonadMockchain m) => m C.TxIn
 payToPlutusScript = do
-  let tx = execBuildTx' (payToPlutusV1 Defaults.networkId txInscript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
+  let tx = execBuildTx (payToPlutusV1 Defaults.networkId txInscript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
   i <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx
   pure (C.TxIn i (C.TxIx 0))
 
 payToPlutusV2Script :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => m C.TxIn
 payToPlutusV2Script = do
-  let tx = execBuildTx' (payToPlutusV2 Defaults.networkId Scripts.v2SpendingScript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
+  let tx = execBuildTx (payToPlutusV2 Defaults.networkId Scripts.v2SpendingScript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
   i <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx
   pure (C.TxIn i (C.TxIx 0))
 
 spendPlutusScript :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => C.TxIn -> m C.TxId
 spendPlutusScript ref = do
-  let tx = execBuildTx' (spendPlutusV1 ref txInscript () ())
+  let tx = execBuildTx (spendPlutusV1 ref txInscript () ())
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx
 
 spendPlutusV2Script :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => C.TxIn -> m C.TxId
 spendPlutusV2Script ref = do
-  let tx = execBuildTx' (spendPlutusV2 ref Scripts.v2SpendingScript () ())
+  let tx = execBuildTx (spendPlutusV2 ref Scripts.v2SpendingScript () ())
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx
 
 putReferenceScript :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => Wallet -> m C.TxIn
 putReferenceScript wallet = do
   let hsh = C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.v2SpendingScript)
       addr = C.makeShelleyAddressInEra C.ShelleyBasedEraBabbage Defaults.networkId (C.PaymentCredentialByScript hsh) C.NoStakeAddress
-      tx = execBuildTx' $
+      tx = execBuildTx $
             payToPlutusV2Inline addr Scripts.v2SpendingScript (C.lovelaceToValue 10_000_000)
             >> setMinAdaDepositAll Defaults.bundledProtocolParameters
   txId <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty wallet tx
@@ -165,13 +166,13 @@ putReferenceScript wallet = do
 spendPlutusScriptReference :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) =>  C.TxIn -> m C.TxId
 spendPlutusScriptReference txIn = do
   refTxIn <- putReferenceScript Wallet.w1
-  let tx = execBuildTx' (spendPlutusV2Ref txIn refTxIn (Just $ C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.v2SpendingScript)) () ())
+  let tx = execBuildTx (spendPlutusV2Ref txIn refTxIn (Just $ C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.v2SpendingScript)) () ())
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx
 
 mintingPlutus :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => m C.TxId
 mintingPlutus = do
   void $ Wallet.w2 `paymentTo` Wallet.w1
-  let tx = execBuildTx' (mintPlutusV1 mintingScript () "assetName" 100)
+  let tx = execBuildTx (mintPlutusV1 mintingScript () "assetName" 100)
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx
 
 spendTokens :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => C.TxId -> m C.TxId
@@ -188,7 +189,7 @@ spendTokens2 txi = do
       wTo = Wallet.w2
       wFrom = Wallet.w1
       vl = assetValue (C.hashScript $ C.PlutusScript C.PlutusScriptV1 mintingScript) "assetName" q
-      tx = execBuildTx' $ do
+      tx = execBuildTx $ do
             payToAddress (Wallet.addressInEra Defaults.networkId wTo) vl
             BuildTx.spendPublicKeyOutput (C.TxIn txi (C.TxIx 0))
             mintPlutusV1 mintingScript () "assetName" (-2)
@@ -215,7 +216,7 @@ spendSingletonOutput txi = do
 nativeAssetPaymentTo :: (MonadMockchain m, MonadFail m, MonadError BalanceTxError m) => C.Quantity -> Wallet -> Wallet -> m C.TxId
 nativeAssetPaymentTo q wFrom wTo = do
   let vl = assetValue (C.hashScript $ C.PlutusScript C.PlutusScriptV1 mintingScript) "assetName" q
-      tx = execBuildTx' $
+      tx = execBuildTx $
             payToAddress (Wallet.addressInEra Defaults.networkId wTo) vl
             >> setMinAdaDepositAll Defaults.bundledProtocolParameters
   -- create a public key output for the sender to make
@@ -268,7 +269,7 @@ checkResolveDatumHash = do
 execBuildTxWallet :: (MonadMockchain m, MonadError BalanceTxError m) => Wallet -> BuildTxT m a -> m (Either SendTxFailed C.TxId)
 execBuildTxWallet wallet action = do
   tx <- execBuildTxT (action >> setMinAdaDepositAll Defaults.bundledProtocolParameters)
-  fmap (C.getTxId . C.getTxBody) <$> balanceAndSubmit mempty wallet (BuildTx.buildTx tx)
+  fmap (C.getTxId . C.getTxBody) <$> balanceAndSubmit mempty wallet tx
 
 {-| Build a transaction, then balance and sign it with the wallet, then
   submit it to the mockchain. Fail if 'balanceAndSubmit' is not successful.
@@ -298,7 +299,7 @@ balanceMultiAddress = do
               -- send the entire amount back to Wallet.w2
               walletAddr <- Wallet.addressInEra <$> networkId <*> pure Wallet.w2
               protParams <- queryProtocolParameters
-              let tx = execBuildTx' $ do
+              let tx = execBuildTx $ do
                         payToAddress walletAddr $ C.lovelaceToValue $ C.quantityToLovelace nAmount
                         traverse_ addRequiredSignature (fmap (C.verificationKeyHash . verificationKey . oPaymentKey) requiredSignatures)
                         setMinAdaDepositAll protParams
@@ -333,7 +334,6 @@ buildTxMixedInputs = mockchainSucceeds $ failOnError $ do
   -- so that there is enough Ada for the transaction fees.
   void
     $ balanceAndSubmit mempty testWallet
-    $ BuildTx.buildTx
     $ BuildTx.execBuildTx
     $ payToAddress (Wallet.addressInEra Defaults.networkId Wallet.w1) utxoVal
 
@@ -361,26 +361,26 @@ largeTransactionTest = do
 
 matchingIndex :: (MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => m ()
 matchingIndex = do
-  let txBody = execBuildTx' (payToPlutusV2 Defaults.networkId Scripts.matchingIndexValidatorScript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
+  let txBody = execBuildTx (payToPlutusV2 Defaults.networkId Scripts.matchingIndexValidatorScript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
       tx     = C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody) <*> pure (C.TxIx 0)
 
   -- create three separate tx outputs that are locked by the matching index script
   inputs <- replicateM 3 tx
 
   -- Spend the outputs in a single transaction
-  void (tryBalanceAndSubmit mempty Wallet.w1 $ execBuildTx' $ traverse_ Scripts.spendMatchingIndex inputs)
+  void (tryBalanceAndSubmit mempty Wallet.w1 $ execBuildTx $ traverse_ Scripts.spendMatchingIndex inputs)
 
 stakingCredential :: C.StakeCredential
 stakingCredential = C.StakeCredentialByScript $ C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.v2StakingScript)
 
 registerStakingCredential :: (MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => m C.TxIn
 registerStakingCredential = do
-  let txBody = execBuildTx' (BuildTx.addStakeCredentialCertificate stakingCredential)
+  let txBody = execBuildTx (BuildTx.addStakeCredentialCertificate stakingCredential)
   C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody) <*> pure (C.TxIx 0)
 
 withdrawZero :: (MonadIO m, MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => m ()
 withdrawZero = do
-  txBody <- BuildTx.buildTx <$> execBuildTxT (BuildTx.addWithdrawZeroPlutusV2InTransaction Scripts.v2StakingScript ())
+  txBody <- execBuildTxT (BuildTx.addWithdrawZeroPlutusV2InTransaction Scripts.v2StakingScript ())
   txI <- C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody) <*> pure (C.TxIx 0)
   singleUTxO txI >>= \case
     Nothing -> fail "txI not found"
@@ -391,4 +391,4 @@ matchingIndexMP = do
   let sh = C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.matchingIndexMPScript)
       policyId = C.PolicyId sh
       runTx assetName = Scripts.mintMatchingIndex policyId assetName 100
-  void $ tryBalanceAndSubmit mempty Wallet.w1 $ execBuildTx' $ traverse_ runTx ["assetName1", "assetName2", "assetName3"]
+  void $ tryBalanceAndSubmit mempty Wallet.w1 $ execBuildTx $ traverse_ runTx ["assetName1", "assetName2", "assetName3"]

--- a/src/devnet/lib/Convex/Devnet/CardanoNode.hs
+++ b/src/devnet/lib/Convex/Devnet/CardanoNode.hs
@@ -51,7 +51,7 @@ import           Control.Lens                     (over)
 import           Control.Monad                    (unless, when, (>=>))
 import           Control.Monad.Except             (runExceptT)
 import           Control.Tracer                   (Tracer, traceWith)
-import           Convex.BuildTx                   (addCertificate, execBuildTx',
+import           Convex.BuildTx                   (addCertificate, execBuildTx,
                                                    payToAddress)
 import           Convex.Devnet.CardanoNode.Types  (GenesisConfigChanges (..),
                                                    Port, PortsConfig (..),
@@ -576,16 +576,16 @@ withCardanoStakePoolNodeDevnetConfig tracer stateDirectory wallet params nodeCon
     Right res -> pure res
 
   let
-    stakeCertTx = execBuildTx' $ do
+    stakeCertTx = execBuildTx $ do
       addCertificate stakeCert
 
-    poolCertTx = execBuildTx' $ do
+    poolCertTx = execBuildTx $ do
       let pledge = spnPledge params
       when (pledge > 0) $
         payToAddress paymentAddress (C.lovelaceToValue pledge)
       addCertificate poolCert
 
-    delegCertTx = execBuildTx' $ do
+    delegCertTx = execBuildTx $ do
       addCertificate delegationCert
 
   _ <- W.balanceAndSubmit mempty node wallet stakeCertTx []

--- a/src/mockchain/lib/Convex/MockChain.hs
+++ b/src/mockchain/lib/Convex/MockChain.hs
@@ -427,7 +427,7 @@ addDatumHashes (C.Tx (ShelleyTxBody C.ShelleyBasedEraBabbage txBody _scripts scr
 
   for_ txOuts $ \(view (L._TxOut . _3) -> txDat) -> case txDat of
     C.TxOutDatumInline _ dat -> insertHashableScriptData dat
-    _                                  -> pure ()
+    _                        -> pure ()
 
   case scriptData of
     C.TxBodyScriptData _ (unTxDats -> txDats) _redeemers -> do

--- a/src/node-client/lib/Convex/NodeClient/WaitForTxnClient.hs
+++ b/src/node-client/lib/Convex/NodeClient/WaitForTxnClient.hs
@@ -12,8 +12,7 @@ module Convex.NodeClient.WaitForTxnClient(
 ) where
 
 import           Cardano.Api                (BlockInMode, ChainPoint, Env,
-                                             LocalNodeConnectInfo,
-                                             TxId)
+                                             LocalNodeConnectInfo, TxId)
 import qualified Cardano.Api                as C
 import           Control.Concurrent         (forkIO)
 import           Control.Concurrent.STM     (TMVar, atomically, newEmptyTMVar,

--- a/src/plutarch/test/Spec.hs
+++ b/src/plutarch/test/Spec.hs
@@ -5,7 +5,7 @@ module Main where
 
 import qualified Cardano.Api.Shelley            as C
 import           Control.Monad                  (void)
-import           Convex.BuildTx                 (execBuildTx', payToPlutusV2,
+import           Convex.BuildTx                 (execBuildTx, payToPlutusV2,
                                                  spendPlutusV2)
 import           Convex.Class                   (MonadMockchain)
 import           Convex.MockChain.CoinSelection (tryBalanceAndSubmit)
@@ -38,6 +38,6 @@ tests = testGroup "plutarch"
 alwaysSucceeds :: (MonadFail m, MonadMockchain m) => m ()
 alwaysSucceeds = failOnError $ do
   k <- either (fail . Text.unpack) (pure . plutarchScriptToCapiScript) (compile NoTracing alwaysSucceedsP)
-  ref <- fmap (C.getTxId . C.getTxBody) $ tryBalanceAndSubmit mempty Wallet.w1 $ execBuildTx' $ do
+  ref <- fmap (C.getTxId . C.getTxBody) $ tryBalanceAndSubmit mempty Wallet.w1 $ execBuildTx $ do
           payToPlutusV2 Defaults.networkId k () C.NoStakeAddress (C.lovelaceToValue 10_000_000)
-  void $ tryBalanceAndSubmit mempty Wallet.w1 $ execBuildTx' (spendPlutusV2 (C.TxIn ref (C.TxIx 0)) k () ())
+  void $ tryBalanceAndSubmit mempty Wallet.w1 $ execBuildTx (spendPlutusV2 (C.TxIn ref (C.TxIx 0)) k () ())


### PR DESCRIPTION
As long as inputs can still be added to the transaction we need to use the `TxBuilder` type. This is because adding inputs can potentially mess up some of the redeemers that were created within the `TxBuilder`. If we use `TxBuilder` instead of `TxBodyContent` then we can create the updated and correct `TxBodyContent` whenever we need it.