### PR TITLE
Add change output position to balancing functions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -34,3 +34,15 @@ packages:
   src/optics
   src/wallet
 
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/io-sim
+  tag: a22dced7d012d10227ab0fe370889665c064caf9
+  subdir:
+    io-sim
+    io-classes
+    io-classes-mtl
+    si-timers
+    strict-stm
+    strict-mvar
+  --sha256: U8DERJj4t1h8kVwv9NovfKuxfTgb1E15q2EAhAT6Zes=

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1714749809,
-        "narHash": "sha256-lIIwnXo+h0z5omBWTCe/FWsEcjpC50VfqO4TOwUFO00=",
+        "lastModified": 1720033323,
+        "narHash": "sha256-R5vrnnT8KcNeph7OOcKxuI3g/xpubi2h+6IMNgFHYes=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "25684d60a9c139abc1c03b6938125f48f5996769",
+        "rev": "676fd75eff463c783fbbb729498c967a6f5eb71d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,10 +32,6 @@
                   };
                 };
                 inputMap = { "https://chap.intersectmbo.org/" = CHaP; };
-                sha256map = {
-                  "https://github.com/Plutonomicon/plutarch-plutus"."fcdd2209433d8b8979e820dc4fa9aad5f202216d" = "sha256-gQwaYGIds5owHivXi+ktH7CGeBqoLBykVxyHZZiDUM4=";
-                  "https://github.com/input-output-hk/xsy-liqwid-libs"."a799bcca72bcd133cc25a7b6841acb48b3885138" = "sha256-ibAtsyejc3SOUWKoyxSQ5r3jg9eOfyEHkpO+qTrwa2U=";
-                };
               };
             })
           ];

--- a/src/coin-selection/lib/Convex/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection.hs
@@ -568,18 +568,33 @@ checkCompatibilityLevel tr (BuildTx.buildTx -> txB) (UtxoSet w) = do
 
 {-| Balance the transaction using the wallet's funds, then sign it.
 -}
-balanceForWallet :: (MonadBlockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> UtxoSet C.CtxUTxO a -> TxBuilder -> m (C.Tx ERA, BalanceChanges)
-balanceForWallet dbg wallet walletUtxo txb = do
+balanceForWallet ::
+  (MonadBlockchain m, MonadError BalanceTxError m) =>
+  Tracer m TxBalancingMessage ->
+  Wallet ->
+  UtxoSet C.CtxUTxO a ->
+  TxBuilder ->
+  ChangeOutputPosition ->
+  m (C.Tx ERA, BalanceChanges)
+balanceForWallet dbg wallet walletUtxo txb changePosition = do
   n <- networkId
   let walletAddress = Wallet.addressInEra n wallet
       txOut = L.emptyTxOut walletAddress
-  balanceForWalletReturn dbg wallet walletUtxo txOut txb
+  balanceForWalletReturn dbg wallet walletUtxo txOut txb changePosition
 
 {-| Balance the transaction using the wallet's funds and the provided return output, then sign it.
 -}
-balanceForWalletReturn :: (MonadBlockchain m, MonadError BalanceTxError m) => Tracer m TxBalancingMessage -> Wallet -> UtxoSet C.CtxUTxO a -> C.TxOut C.CtxTx C.BabbageEra -> TxBuilder -> m (C.Tx ERA, BalanceChanges)
-balanceForWalletReturn dbg wallet walletUtxo returnOutput txb = do
-  first (signForWallet wallet) <$> balanceTx dbg returnOutput walletUtxo txb
+balanceForWalletReturn ::
+  (MonadBlockchain m, MonadError BalanceTxError m) =>
+  Tracer m TxBalancingMessage ->
+  Wallet ->
+  UtxoSet C.CtxUTxO a ->
+  C.TxOut C.CtxTx C.BabbageEra ->
+  TxBuilder ->
+  ChangeOutputPosition ->
+  m (C.Tx ERA, BalanceChanges)
+balanceForWalletReturn dbg wallet walletUtxo returnOutput txb changePosition = do
+  first (signForWallet wallet) <$> balanceTx dbg returnOutput walletUtxo txb changePosition
 
 {-| Sign a transaction with the wallet's key
 -}

--- a/src/coin-selection/lib/Convex/CoinSelection/Class.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection/Class.hs
@@ -28,7 +28,7 @@ import           Convex.BuildTx                   (TxBuilder)
 import           Convex.Class                     (MonadBlockchain (..),
                                                    MonadMockchain (..),
                                                    MonadDatumQuery (queryDatumFromHash))
-import           Convex.CoinSelection             (BalanceTxError,
+import           Convex.CoinSelection             (BalanceTxError, ChangeOutputPosition,
                                                    TxBalancingMessage)
 import qualified Convex.CoinSelection
 import           Convex.CardanoApi.Lenses         (emptyTxOut)
@@ -63,6 +63,9 @@ class Monad m => MonadBalance m where
     -- | The unbalanced transaction body
     TxBuilder ->
 
+    -- | The position of the change output
+    ChangeOutputPosition ->
+
     -- | The balanced transaction body and the balance changes (per address)
     m (Either BalanceTxError (C.BalancedTxBody BabbageEra, BalanceChanges))
 
@@ -75,22 +78,22 @@ instance MonadTrans BalancingT where
 deriving newtype instance MonadError e m => MonadError e (BalancingT m)
 
 instance MonadBalance m => MonadBalance (ExceptT e m) where
-  balanceTx addr utxos = lift . balanceTx addr utxos
+  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
 
 instance MonadBalance m => MonadBalance (ReaderT e m) where
-  balanceTx addr utxos = lift . balanceTx addr utxos
+  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
 
 instance MonadBalance m => MonadBalance (StrictState.StateT s m) where
-  balanceTx addr utxos = lift . balanceTx addr utxos
+  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
 
 instance MonadBalance m => MonadBalance (LazyState.StateT s m) where
-  balanceTx addr utxos = lift . balanceTx addr utxos
+  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
 
 instance MonadBalance m => MonadBalance (MonadLogIgnoreT m) where
-  balanceTx addr utxos = lift . balanceTx addr utxos
+  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
 
 instance (MonadBlockchain m) => MonadBalance (BalancingT m) where
-  balanceTx addr utxos txb = runExceptT (Convex.CoinSelection.balanceTx mempty (emptyTxOut addr) utxos txb)
+  balanceTx addr utxos txb changePosition = runExceptT (Convex.CoinSelection.balanceTx mempty (emptyTxOut addr) utxos txb changePosition)
 
 instance MonadMockchain m => MonadMockchain (BalancingT m) where
   setReward cred = lift . setReward cred
@@ -114,9 +117,9 @@ instance MonadTrans TracingBalancingT where
 deriving newtype instance MonadError e m => MonadError e (TracingBalancingT m)
 
 instance (MonadBlockchain m) => MonadBalance (TracingBalancingT m) where
-  balanceTx addr utxos txb = TracingBalancingT $ do
+  balanceTx addr utxos txb changePosition = TracingBalancingT $ do
     tr <- ask
-    runExceptT (Convex.CoinSelection.balanceTx (natTracer (lift . lift) tr) (emptyTxOut addr) utxos txb)
+    runExceptT (Convex.CoinSelection.balanceTx (natTracer (lift . lift) tr) (emptyTxOut addr) utxos txb changePosition)
 
 instance MonadMockchain m => MonadMockchain (TracingBalancingT m) where
   setReward cred = lift . setReward cred

--- a/src/coin-selection/lib/Convex/MockChain/Staking.hs
+++ b/src/coin-selection/lib/Convex/MockChain/Staking.hs
@@ -7,7 +7,7 @@ import           Control.Monad.Except           (MonadError)
 import           Control.Monad.IO.Class         (MonadIO (..))
 import qualified Convex.BuildTx                 as BuildTx
 import           Convex.Class                   (MonadMockchain)
-import           Convex.CoinSelection           (BalanceTxError)
+import           Convex.CoinSelection           (BalanceTxError, ChangeOutputPosition (TrailingChange))
 import           Convex.MockChain.CoinSelection (tryBalanceAndSubmit)
 import qualified Convex.MockChain.Defaults      as Defaults
 import           Convex.Wallet                  (Wallet)
@@ -70,8 +70,8 @@ registerPool wallet = do
     delegCertTx = BuildTx.execBuildTx $ do
       BuildTx.addCertificate delegationCert
 
-  void $ tryBalanceAndSubmit mempty wallet stakeCertTx []
-  void $ tryBalanceAndSubmit mempty wallet poolCertTx [C.WitnessStakeKey stakeKey, C.WitnessStakePoolKey stakePoolKey]
-  void $ tryBalanceAndSubmit mempty wallet delegCertTx [C.WitnessStakeKey stakeKey]
+  void $ tryBalanceAndSubmit mempty wallet stakeCertTx TrailingChange []
+  void $ tryBalanceAndSubmit mempty wallet poolCertTx TrailingChange [C.WitnessStakeKey stakeKey, C.WitnessStakePoolKey stakePoolKey]
+  void $ tryBalanceAndSubmit mempty wallet delegCertTx TrailingChange [C.WitnessStakeKey stakeKey]
 
   pure poolId

--- a/src/coin-selection/test/Spec.hs
+++ b/src/coin-selection/test/Spec.hs
@@ -33,8 +33,8 @@ import           Convex.Class                   (MonadBlockchain (..),
                                                  MonadDatumQuery (queryDatumFromHash),
                                                  SendTxFailed (..), getUtxo,
                                                  setUtxo, singleUTxO, setReward)
-import           Convex.CoinSelection           (BalanceTxError, keyWitnesses,
-                                                 publicKeyCredential)
+import           Convex.CoinSelection           (BalanceTxError, ChangeOutputPosition (TrailingChange),
+                                                 keyWitnesses, publicKeyCredential)
 import qualified Convex.CardanoApi.Lenses                  as L
 import           Convex.MockChain               (ValidationError (..),
                                                  failedTransactions,
@@ -130,24 +130,24 @@ mintingScript = C.examplePlutusScriptAlwaysSucceeds C.WitCtxMint
 payToPlutusScript :: (MonadFail m, MonadError BalanceTxError m, MonadMockchain m) => m C.TxIn
 payToPlutusScript = do
   let tx = execBuildTx (payToPlutusV1 Defaults.networkId txInscript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
-  i <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx []
+  i <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
   pure (C.TxIn i (C.TxIx 0))
 
 payToPlutusV2Script :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => m C.TxIn
 payToPlutusV2Script = do
   let tx = execBuildTx (payToPlutusV2 Defaults.networkId Scripts.v2SpendingScript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
-  i <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx []
+  i <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
   pure (C.TxIn i (C.TxIx 0))
 
 spendPlutusScript :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => C.TxIn -> m C.TxId
 spendPlutusScript ref = do
   let tx = execBuildTx (spendPlutusV1 ref txInscript () ())
-  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx []
+  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
 
 spendPlutusV2Script :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => C.TxIn -> m C.TxId
 spendPlutusV2Script ref = do
   let tx = execBuildTx (spendPlutusV2 ref Scripts.v2SpendingScript () ())
-  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx []
+  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
 
 putReferenceScript :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => Wallet -> m C.TxIn
 putReferenceScript wallet = do
@@ -156,7 +156,7 @@ putReferenceScript wallet = do
       tx = execBuildTx $
             payToPlutusV2Inline addr Scripts.v2SpendingScript (C.lovelaceToValue 10_000_000)
             >> setMinAdaDepositAll Defaults.bundledProtocolParameters
-  txId <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty wallet tx []
+  txId <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty wallet tx TrailingChange []
   let outRef = C.TxIn txId (C.TxIx 0)
   C.UTxO utxo <- utxoByTxIn (Set.singleton outRef)
   case Map.lookup outRef utxo of
@@ -170,13 +170,13 @@ spendPlutusScriptReference :: (MonadFail m, MonadMockchain m, MonadError Balance
 spendPlutusScriptReference txIn = do
   refTxIn <- putReferenceScript Wallet.w1
   let tx = execBuildTx (spendPlutusV2Ref txIn refTxIn (Just $ C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.v2SpendingScript)) () ())
-  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx []
+  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
 
 mintingPlutus :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => m C.TxId
 mintingPlutus = do
   void $ Wallet.w2 `paymentTo` Wallet.w1
   let tx = execBuildTx (mintPlutusV1 mintingScript () "assetName" 100)
-  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx []
+  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
 
 spendTokens :: (MonadFail m, MonadMockchain m, MonadError BalanceTxError m) => C.TxId -> m C.TxId
 spendTokens _ = do
@@ -198,7 +198,7 @@ spendTokens2 txi = do
             mintPlutusV1 mintingScript () "assetName" (-2)
             setMinAdaDepositAll Defaults.bundledProtocolParameters
   void $ wTo `paymentTo` wFrom
-  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty wFrom tx []
+  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty wFrom tx TrailingChange []
 
 -- | Put all of the Wallet 2's funds into a single UTxO with mixed assets
 --   Then make a transaction that splits this output into two
@@ -225,7 +225,7 @@ nativeAssetPaymentTo q wFrom wTo = do
   -- create a public key output for the sender to make
   -- sure that the sender has enough Ada in ada-only inputs
   void $ wTo `paymentTo` wFrom
-  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty wFrom tx []
+  C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty wFrom tx TrailingChange []
 
 checkResolveDatumHash :: (MonadMockchain m, MonadDatumQuery m, MonadFail m, MonadError BalanceTxError m) => m ()
 checkResolveDatumHash = do
@@ -272,7 +272,7 @@ checkResolveDatumHash = do
 execBuildTxWallet :: (MonadMockchain m, MonadError BalanceTxError m) => Wallet -> BuildTxT m a -> m (Either SendTxFailed C.TxId)
 execBuildTxWallet wallet action = do
   tx <- execBuildTxT (action >> setMinAdaDepositAll Defaults.bundledProtocolParameters)
-  fmap (C.getTxId . C.getTxBody) <$> balanceAndSubmit mempty wallet tx []
+  fmap (C.getTxId . C.getTxBody) <$> balanceAndSubmit mempty wallet tx TrailingChange []
 
 {-| Build a transaction, then balance and sign it with the wallet, then
   submit it to the mockchain. Fail if 'balanceAndSubmit' is not successful.
@@ -308,7 +308,7 @@ balanceMultiAddress = do
                         setMinAdaDepositAll protParams
 
               -- balance the tx using all of the operators' addressses
-              balancedTx <- runExceptT (balancePaymentCredentials mempty (operatorPaymentCredential op) (operatorPaymentCredential <$> operators) Nothing tx) >>= either (fail . show) pure
+              balancedTx <- runExceptT (balancePaymentCredentials mempty (operatorPaymentCredential op) (operatorPaymentCredential <$> operators) Nothing tx TrailingChange) >>= either (fail . show) pure
               txInputs <- let C.Tx (C.TxBody txBody) _ = balancedTx in keyWitnesses txBody
               let (Set.fromList -> extraWits) = let C.Tx (C.TxBody txBody) _ = balancedTx in view (L.txExtraKeyWits . L._TxExtraKeyWitnesses) txBody
               -- add the required operators' signatures
@@ -337,7 +337,7 @@ buildTxMixedInputs = mockchainSucceeds $ failOnError $ do
   -- so that there is enough Ada for the transaction fees.
   void
     $ balanceAndSubmit mempty testWallet
-      (BuildTx.execBuildTx (payToAddress (Wallet.addressInEra Defaults.networkId Wallet.w1) utxoVal)) []
+      (BuildTx.execBuildTx (payToAddress (Wallet.addressInEra Defaults.networkId Wallet.w1) utxoVal)) TrailingChange []
 
 
 largeTransactionTest :: Assertion
@@ -364,13 +364,13 @@ largeTransactionTest = do
 matchingIndex :: (MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => m ()
 matchingIndex = do
   let txBody = execBuildTx (payToPlutusV2 Defaults.networkId Scripts.matchingIndexValidatorScript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
-      tx     = C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody []) <*> pure (C.TxIx 0)
+      tx     = C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange []) <*> pure (C.TxIx 0)
 
   -- create three separate tx outputs that are locked by the matching index script
   inputs <- replicateM 3 tx
 
   -- Spend the outputs in a single transaction
-  void (tryBalanceAndSubmit mempty Wallet.w1 (execBuildTx $ traverse_ Scripts.spendMatchingIndex inputs) [])
+  void (tryBalanceAndSubmit mempty Wallet.w1 (execBuildTx $ traverse_ Scripts.spendMatchingIndex inputs) TrailingChange [])
 
 stakingCredential :: C.StakeCredential
 stakingCredential = C.StakeCredentialByScript $ C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.v2StakingScript)
@@ -378,12 +378,12 @@ stakingCredential = C.StakeCredentialByScript $ C.hashScript (C.PlutusScript C.P
 registerStakingCredential :: (MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => m C.TxIn
 registerStakingCredential = do
   let txBody = execBuildTx (BuildTx.addStakeCredentialCertificate stakingCredential)
-  C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody []) <*> pure (C.TxIx 0)
+  C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange []) <*> pure (C.TxIx 0)
 
 withdrawZero :: (MonadIO m, MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => m ()
 withdrawZero = do
   txBody <- execBuildTxT (BuildTx.addWithdrawZeroPlutusV2InTransaction Scripts.v2StakingScript ())
-  txI <- C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody []) <*> pure (C.TxIx 0)
+  txI <- C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange []) <*> pure (C.TxIx 0)
   singleUTxO txI >>= \case
     Nothing -> fail "txI not found"
     Just{} -> pure ()
@@ -393,7 +393,7 @@ matchingIndexMP = do
   let sh = C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.matchingIndexMPScript)
       policyId = C.PolicyId sh
       runTx assetName = Scripts.mintMatchingIndex policyId assetName 100
-  void $ tryBalanceAndSubmit mempty Wallet.w1 (execBuildTx $ traverse_ runTx ["assetName1", "assetName2", "assetName3"]) []
+  void $ tryBalanceAndSubmit mempty Wallet.w1 (execBuildTx $ traverse_ runTx ["assetName1", "assetName2", "assetName3"]) TrailingChange []
 
 queryStakeAddressesTest :: forall m. (MonadIO m, MonadMockchain m, MonadError BalanceTxError m, MonadFail m) => m ()
 queryStakeAddressesTest = do
@@ -423,9 +423,9 @@ queryStakeAddressesTest = do
       BuildTx.addCertificate delegationCert
 
   -- activate stake
-  void $ tryBalanceAndSubmit mempty Wallet.w2 stakeCertTx []
-  -- delegate to pool 
-  void $ tryBalanceAndSubmit mempty Wallet.w2 delegCertTx [C.WitnessStakeKey stakeKey]
+  void $ tryBalanceAndSubmit mempty Wallet.w2 stakeCertTx TrailingChange []
+  -- delegate to pool
+  void $ tryBalanceAndSubmit mempty Wallet.w2 delegCertTx TrailingChange [C.WitnessStakeKey stakeKey]
 
   -- modify the ledger state
   setReward stakeCred (C.quantityToLovelace withdrawalAmount)
@@ -467,12 +467,12 @@ withdrawalTest = do
       BuildTx.addWithdrawal stakeAddress withdrawalAmount (C.KeyWitness C.KeyWitnessForStakeAddr)
 
   -- activate stake
-  void $ tryBalanceAndSubmit mempty Wallet.w2 stakeCertTx []
-  -- delegate to pool 
-  void $ tryBalanceAndSubmit mempty Wallet.w2 delegCertTx [C.WitnessStakeKey stakeKey]
+  void $ tryBalanceAndSubmit mempty Wallet.w2 stakeCertTx TrailingChange []
+  -- delegate to pool
+  void $ tryBalanceAndSubmit mempty Wallet.w2 delegCertTx TrailingChange [C.WitnessStakeKey stakeKey]
 
   -- modify the ledger state
   setReward stakeCred (C.quantityToLovelace withdrawalAmount)
 
   -- withdraw rewards
-  void $ tryBalanceAndSubmit mempty Wallet.w2 withdrawalTx [C.WitnessStakeKey stakeKey]
+  void $ tryBalanceAndSubmit mempty Wallet.w2 withdrawalTx TrailingChange [C.WitnessStakeKey stakeKey]

--- a/src/devnet/lib/Convex/Devnet/CardanoNode.hs
+++ b/src/devnet/lib/Convex/Devnet/CardanoNode.hs
@@ -53,6 +53,7 @@ import           Control.Monad.Except             (runExceptT)
 import           Control.Tracer                   (Tracer, traceWith)
 import           Convex.BuildTx                   (addCertificate, execBuildTx,
                                                    payToAddress)
+import           Convex.CoinSelection             (ChangeOutputPosition (TrailingChange))
 import           Convex.Devnet.CardanoNode.Types  (GenesisConfigChanges (..),
                                                    Port, PortsConfig (..),
                                                    RunningNode (..),
@@ -588,13 +589,13 @@ withCardanoStakePoolNodeDevnetConfig tracer stateDirectory wallet params nodeCon
     delegCertTx = execBuildTx $ do
       addCertificate delegationCert
 
-  _ <- W.balanceAndSubmit mempty node wallet stakeCertTx []
+  _ <- W.balanceAndSubmit mempty node wallet stakeCertTx TrailingChange []
   _ <- waitForNextBlock node
 
-  _ <- W.balanceAndSubmit mempty node wallet poolCertTx [C.WitnessStakeKey stakeKey, C.WitnessStakePoolKey stakePoolKey]
+  _ <- W.balanceAndSubmit mempty node wallet poolCertTx TrailingChange [C.WitnessStakeKey stakeKey, C.WitnessStakePoolKey stakePoolKey]
   _ <- waitForNextBlock node
 
-  _ <- W.balanceAndSubmit mempty node wallet delegCertTx [C.WitnessStakeKey stakeKey]
+  _ <- W.balanceAndSubmit mempty node wallet delegCertTx TrailingChange [C.WitnessStakeKey stakeKey]
   _ <- waitForNextBlock node
 
   vrfKeyFile <- writeEnvelope vrfKey "vrf.skey"

--- a/src/devnet/lib/Convex/Devnet/Wallet.hs
+++ b/src/devnet/lib/Convex/Devnet/Wallet.hs
@@ -96,12 +96,12 @@ runningNodeBlockchain tracer RunningNode{rnNodeSocket, rnNetworkId} h =
 
 {-| Balance and submit the transaction using the wallet's UTXOs
 -}
-balanceAndSubmit :: Tracer IO WalletLog -> RunningNode -> Wallet -> TxBuilder -> [C.ShelleyWitnessSigningKey] -> IO (Tx BabbageEra)
-balanceAndSubmit tracer node wallet tx keys = do
+balanceAndSubmit :: Tracer IO WalletLog -> RunningNode -> Wallet -> TxBuilder -> ChangeOutputPosition -> [C.ShelleyWitnessSigningKey] -> IO (Tx BabbageEra)
+balanceAndSubmit tracer node wallet tx changePosition keys = do
   n <- runningNodeBlockchain @String tracer node networkId
   let walletAddress = Wallet.addressInEra n wallet
       txOut = emptyTxOut walletAddress
-  balanceAndSubmitReturn tracer node wallet txOut tx keys
+  balanceAndSubmitReturn tracer node wallet txOut tx changePosition keys
 
 {-| Balance and submit the transaction using the wallet's UTXOs
 -}

--- a/src/devnet/lib/Convex/Devnet/Wallet.hs
+++ b/src/devnet/lib/Convex/Devnet/Wallet.hs
@@ -35,7 +35,7 @@ import qualified Convex.BuildTx                  as BuildTx
 import           Convex.Class                    (MonadBlockchain (networkId),
                                                   runMonadBlockchainCardanoNodeT,
                                                   sendTx)
-import           Convex.CoinSelection            (ChangeOutputPosition)
+import           Convex.CoinSelection            (ChangeOutputPosition (TrailingChange))
 import qualified Convex.CoinSelection            as CoinSelection
 import           Convex.Devnet.CardanoNode.Types (RunningNode (..))
 import qualified Convex.Devnet.NodeQueries       as NodeQueries
@@ -68,7 +68,7 @@ walletUtxos RunningNode{rnNodeSocket, rnNetworkId} wllt =
 sendFaucetFundsTo :: Tracer IO WalletLog -> RunningNode -> AddressInEra BabbageEra -> Int -> Quantity -> IO (Tx BabbageEra)
 sendFaucetFundsTo tracer node destination n amount = do
   fct <- faucet
-  balanceAndSubmit tracer node fct (BuildTx.execBuildTx $ replicateM n (BuildTx.payToAddress destination (C.lovelaceToValue $ C.quantityToLovelace amount))) []
+  balanceAndSubmit tracer node fct (BuildTx.execBuildTx $ replicateM n (BuildTx.payToAddress destination (C.lovelaceToValue $ C.quantityToLovelace amount))) TrailingChange []
 
 {-| Create a new wallet and send @n@ times the given amount of lovelace to it. Returns when the seed txn has been registered
 on the chain.

--- a/src/devnet/lib/Convex/Devnet/Wallet.hs
+++ b/src/devnet/lib/Convex/Devnet/Wallet.hs
@@ -35,6 +35,7 @@ import qualified Convex.BuildTx                  as BuildTx
 import           Convex.Class                    (MonadBlockchain (networkId),
                                                   runMonadBlockchainCardanoNodeT,
                                                   sendTx)
+import           Convex.CoinSelection            (ChangeOutputPosition)
 import qualified Convex.CoinSelection            as CoinSelection
 import           Convex.Devnet.CardanoNode.Types (RunningNode (..))
 import qualified Convex.Devnet.NodeQueries       as NodeQueries
@@ -104,11 +105,11 @@ balanceAndSubmit tracer node wallet tx keys = do
 
 {-| Balance and submit the transaction using the wallet's UTXOs
 -}
-balanceAndSubmitReturn :: Tracer IO WalletLog -> RunningNode -> Wallet -> C.TxOut C.CtxTx C.BabbageEra -> TxBuilder -> [C.ShelleyWitnessSigningKey] -> IO (Tx BabbageEra)
-balanceAndSubmitReturn tracer node wallet returnOutput tx keys = do
+balanceAndSubmitReturn :: Tracer IO WalletLog -> RunningNode -> Wallet -> C.TxOut C.CtxTx C.BabbageEra -> TxBuilder -> ChangeOutputPosition -> [C.ShelleyWitnessSigningKey] -> IO (Tx BabbageEra)
+balanceAndSubmitReturn tracer node wallet returnOutput tx changePosition keys = do
   utxos <- walletUtxos node wallet
   runningNodeBlockchain @String tracer node $ do
-    (C.Tx body wit, _) <- failOnError (CoinSelection.balanceForWalletReturn mempty wallet utxos returnOutput tx)
+    (C.Tx body wit, _) <- failOnError (CoinSelection.balanceForWalletReturn mempty wallet utxos returnOutput tx changePosition)
 
     let wit' = (C.makeShelleyKeyWitness C.ShelleyBasedEraBabbage body <$> keys) ++ wit
         tx'  = C.makeSignedTransaction wit' body

--- a/src/un-ada/test/UnAda/Test/UnitTest.hs
+++ b/src/un-ada/test/UnAda/Test/UnitTest.hs
@@ -15,6 +15,7 @@ import           Convex.Class                   (MonadBlockchain (..),
                                                  MonadMockchain)
 import           Convex.CardanoApi.Lenses                  (emptyTx)
 import qualified Convex.CardanoApi.Lenses                  as L
+import           Convex.CoinSelection           (ChangeOutputPosition (TrailingChange))
 import           Convex.MockChain.CoinSelection (balanceAndSubmit, paymentTo)
 import qualified Convex.MockChain.Defaults      as Defaults
 import           Convex.MockChain.Utils         (mockchainSucceeds)
@@ -57,7 +58,7 @@ mintSomeUnAda :: (MonadFail m, MonadError BalanceTxError m, MonadMockchain m) =>
 mintSomeUnAda = do
   let tx = emptyTx & mintUnAda Defaults.networkId 1 10_000_000
   _ <- Wallet.w2 `paymentTo` Wallet.w1
-  mintingTx <- balanceAndSubmit Wallet.w1 tx
+  mintingTx <- balanceAndSubmit Wallet.w1 tx TrailingChange
   _ <- unAdaPaymentTo 5_000_000 Wallet.w1 Wallet.w2
 
   getUnAdaOutput mintingTx
@@ -69,7 +70,7 @@ canBurnUnAda = mockchainSucceeds $ failOnError $ do
   let tx' = emptyTx & burnUnAda Defaults.networkId 0 txi txo st 3_000_000
   _ <- Wallet.w3 `paymentTo` Wallet.w1
   _ <- Wallet.w2 `paymentTo` Wallet.w1
-  balanceAndSubmit Wallet.w1 tx' >>= getUnAdaOutput
+  balanceAndSubmit Wallet.w1 tx' TrailingChange >>= getUnAdaOutput
 
 unAdaPaymentTo :: (MonadBlockchain m, MonadMockchain m, MonadError BalanceTxError m) => C.Quantity -> Wallet -> Wallet -> m (C.Tx C.BabbageEra)
 unAdaPaymentTo q wFrom wTo = do
@@ -80,7 +81,7 @@ unAdaPaymentTo q wFrom wTo = do
   -- create a public key output for the sender to make
   -- sure that the sender has enough Ada in ada-only inputs
   void $ wTo `paymentTo` wFrom
-  balanceAndSubmit wFrom tx
+  balanceAndSubmit wFrom tx TrailingChange
 
 {-| Get exactly 1 un-Ada output from the transaction. Fails if there are 0 or more than one
 un-Ada outputs.


### PR DESCRIPTION
- Added a new `ChangeOutputPosition` type and argument to most if not all of the balancing function to indicate the change output position when balancing a tx.
- Updated the flake to reflect with the recent cardano bump (I had to add `io-sim` to the `cabal.project` but I'm not sure if it will break non-nix build).