### PR TITLE
Gha job for nix

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -7,11 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v27
-    # This checks the packages compile with the flake checks, see `flake.nix` for detials
+    - uses: cachix/install-nix-action@v25
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v14
+      with:
+        name: sc-tools
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Flake check
       run: nix flake check
-    # This checks the packages compile with cabal
-    - name: Cabal build into develop shell
-      run: nix develop && cabal build all -j
-    

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,17 @@
+name: "Nix"
+on:
+  pull_request:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+    # This checks the packages compile with the flake checks, see `flake.nix` for detials
+    - name: Flake check
+      run: nix flake check
+    # This checks the packages compile with cabal
+    - name: Cabal build into develop shell
+      run: nix develop && cabal build all -j
+    

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A collection of libraries that are helpful for building Cardano apps with Haskel
 * `convex-coin-selection`: Coin selection and transaction balancing
 * `convex-mockchain`: Minimal mockchain for tests
 * `convex-optics`: Some optics for plutus-ledger-api and cardano-api
+
 The API documentation (Haddocks) is published [here](https://j-mueller.github.io/sc-tools/)
 
 ### Dependencies

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
         in
         {
           devShells = flake.devShells;
+          packages = flake.packages;
           checks = {
             build-all = pkgs.runCommandCC "check all cabal.project pagackes"
               {

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,13 @@
         in
         {
           devShells = flake.devShells;
+          checks = {
+            build-all = pkgs.runCommandCC "check all cabal.project pagackes"
+              {
+                buildInputs = builtins.attrValues flake.packages;
+              }
+              "mkdir $out";
+          };
         };
     };
   nixConfig = {


### PR DESCRIPTION
This PR adds:
- all the packages are build when `nix flake check`
- a new GHA job is introduced to check the nix flake works and the packages are correctly build with it: you can check the failures are triggered if:
  - Code does not compile: https://github.com/albertodvp/sc-tools/actions/runs/10027059462/job/27712217717
  - Flake has errors in it: https://github.com/albertodvp/sc-tools/actions/runs/10027054865/job/27712206225

Note:
I've set up a cachix cache for this, to make this work we would have to add a secret (auth token) for the cache to the github repo.
Unfortunately, this is needed because we currently don't have an official cache for the GHC version we are using (9.6.6).
See https://input-output-hk.github.io/haskell.nix/reference/supported-ghc-versions.html

I tried to recompile it in CI but the GHA runner run out of memory (and it takes way longer). We have 5GiB for free, for open source project and we currently use only 2.2GiB and I'm confident the free tier will suffice.
https://app.cachix.org/cache/sc-tools#pull
Centralized caches introduce a trust issue but I think here the risk is very low because we need that only to verify that the flake still work, the code is compiled using a plain cabal in the other GHA job.

**My suggestion** 
is to keep this cache, I can add you as a member to it and you can extract an auth token (following [this guide](https://docs.cachix.org/getting-started#authenticating)) and you add it as a secret of this repo. Or I can extract the auth token myself and send it to you privately.

**Alternative**
If you want to own the cachix cache, you should create a cache yourself and somebody should push manually GHC9.6.6.


Let me know what you think about this


--

Closes #159 