### PR TITLE
Conway hardfork in devnet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Convex.BuildTx`: Added functions for withdrawals, certificates and stake witnesses
 - `Convex.Class`: Add `singleUTxO` function to retrieve a single output from the UTxO set
 - `Convex.Class`: Add `MonadUtxoQuery` class for looking up unspent transaction outputs by payment credential.
+- `Convex.Devnet.CardanoNode.Types`: Add Ability to hardfork to conway era in devnet
 
 ### Deleted
 

--- a/src/devnet/convex-devnet.cabal
+++ b/src/devnet/convex-devnet.cabal
@@ -53,6 +53,7 @@ library
     build-depends:
       base >= 4.14.0
       , aeson
+      , lens-aeson
       , text
       , time
       , bytestring

--- a/src/devnet/lib/Convex/Devnet/CardanoNode.hs
+++ b/src/devnet/lib/Convex/Devnet/CardanoNode.hs
@@ -24,7 +24,7 @@ module Convex.Devnet.CardanoNode(
   withCardanoNodeDevnet,
   allowLargeTransactions,
   withCardanoNodeDevnetConfig,
-  withCardanoStakePoolNodeDevnetConfig
+  withCardanoStakePoolNodeDevnetConfig,
 ) where
 
 import           Cardano.Api                      (NetworkId,
@@ -366,11 +366,12 @@ withCardanoNodeDevnetConfig tracer stateDirectory configChanges PortsConfig{ours
     setFileMode destination ownerReadMode
     pure destination
 
-  GenesisConfigChanges{cfAlonzo, cfConway, cfShelley} = configChanges
+  GenesisConfigChanges{cfAlonzo, cfConway, cfShelley, cfNodeConfig} = configChanges
 
   copyDevnetFiles args = do
     readConfigFile ("devnet" </> "cardano-node.json")
-      >>= BS.writeFile
+      >>= copyAndChangeJSONFile
+        cfNodeConfig
         (stateDirectory </> nodeConfigFile args)
     readConfigFile ("devnet" </> "genesis-byron.json")
       >>= BS.writeFile

--- a/src/devnet/lib/Convex/Devnet/NodeQueries.hs
+++ b/src/devnet/lib/Convex/Devnet/NodeQueries.hs
@@ -17,7 +17,8 @@ module Convex.Devnet.NodeQueries(
   waitForTxIn,
   waitForTxInSpend,
   localNodeConnectInfo,
-  loadConnectInfo
+  loadConnectInfo,
+  queryEra
 ) where
 
 import           Cardano.Api                                        (Address,
@@ -105,6 +106,9 @@ cardanoModeParams = C.CardanoModeParams $ C.EpochSlots defaultByronEpochSlots
 
 queryTipBlock :: NetworkId -> FilePath -> IO (WithOrigin BlockNo)
 queryTipBlock = queryLocalState C.QueryChainBlockNo
+
+queryEra :: NetworkId -> FilePath -> IO C.AnyCardanoEra
+queryEra = queryLocalState C.QueryCurrentEra
 
 queryEpoch :: NetworkId -> FilePath -> IO C.EpochNo
 queryEpoch nid path = do


### PR DESCRIPTION
* Enable conway hardfork in devnet using `Convex.Devnet.CardanoNode.Types.forkIntoConwayInEpoch`. This can be set to 0 to ensure that conway era is the default era from the start.