### PR TITLE
Suport Conway HF

### DIFF
--- a/src/base/convex-base.cabal
+++ b/src/base/convex-base.cabal
@@ -61,6 +61,7 @@ library
       cardano-ledger-core,
       cardano-crypto-wrapper,
 
+      cardano-ledger-api,
       cardano-ledger-byron,
       cardano-ledger-mary,
       cardano-ledger-shelley,

--- a/src/base/convex-base.cabal
+++ b/src/base/convex-base.cabal
@@ -65,6 +65,7 @@ library
       cardano-ledger-shelley,
       cardano-ledger-babbage,
       cardano-ledger-alonzo,
+      cardano-ledger-conway,
 
       ouroboros-consensus,
       ouroboros-consensus-cardano,

--- a/src/base/convex-base.cabal
+++ b/src/base/convex-base.cabal
@@ -31,6 +31,7 @@ library
       Convex.BuildTx
       Convex.Class
       Convex.Constants
+      Convex.Eras
       Convex.MonadLog
       Convex.NodeQueries
       Convex.PlutusLedger

--- a/src/base/convex-base.cabal
+++ b/src/base/convex-base.cabal
@@ -61,7 +61,6 @@ library
       cardano-ledger-core,
       cardano-crypto-wrapper,
 
-      cardano-ledger-api,
       cardano-ledger-byron,
       cardano-ledger-mary,
       cardano-ledger-shelley,

--- a/src/base/lib/Convex/Eras.hs
+++ b/src/base/lib/Convex/Eras.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE GADTs      #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE TypeApplications #-}
 {-| Utilities for dealing with eras
 -}
 module Convex.Eras(
@@ -13,21 +14,32 @@ module Convex.Eras(
   babbageProtocolParams,
   babbageTxOut,
   babbageUTxO,
-  downgradeTxOut
+  upgradeUTxO,
+  downgradeTxOut,
+  upgradeTxBodyContent
 ) where
 
-import           Cardano.Api              (BabbageEra, BabbageEraOnwards (..),
-                                           ConwayEra)
-import           Cardano.Api.Shelley      (CardanoEra (..), CtxUTxO,
-                                           InAnyCardanoEra (..),
-                                           LedgerProtocolParameters (..),
-                                           ReferenceScript (..), TxOut (..),
-                                           TxOutDatum (..), UTxO (..))
-import qualified Cardano.Api.Shelley      as C
-import qualified Cardano.Ledger.Core      as PParams
-import qualified Control.Lens             as L
-import qualified Convex.CardanoApi.Lenses as L
-import           Data.Typeable            (Typeable)
+import           Cardano.Api                  (BabbageEra,
+                                               BabbageEraOnwards (..),
+                                               ConwayEra)
+import           Cardano.Api.Ledger           (Coin, ConwayTxCert (..),
+                                               ShelleyTxCert (..))
+import           Cardano.Api.Shelley          (BuildTx, BuildTxWith (..),
+                                               CardanoEra (..), CtxUTxO,
+                                               InAnyCardanoEra (..),
+                                               LedgerProtocolParameters (..),
+                                               ReferenceScript (..),
+                                               StakeAddress, TxBodyContent (..),
+                                               TxOut (..), TxOutDatum (..),
+                                               UTxO (..), WitCtxStake,
+                                               Witness (..))
+import qualified Cardano.Api.Shelley          as C
+import qualified Cardano.Ledger.Conway.TxCert as L
+import qualified Cardano.Ledger.Core          as PParams
+import qualified Control.Lens                 as L
+import qualified Convex.CardanoApi.Lenses     as L
+import           Data.Bifunctor               (Bifunctor (..))
+import           Data.Typeable                (Typeable)
 
 -- | A value with unknown Babbage-onwards era type.
 --   Similar to Cardano.Api.Eras.Core but for modern eras.
@@ -77,6 +89,9 @@ babbageUTxO = \case
   InAnyBabbageEraOnwards BabbageEraOnwardsConway (UTxO m) ->
     UTxO $ fmap downgradeTxOut m
 
+upgradeUTxO :: C.UTxO BabbageEra -> C.UTxO ConwayEra
+upgradeUTxO (C.UTxO m) = C.UTxO (fmap upgradeTxOut m)
+
 -- | Babbage-era tx outputs. We can always downgrade conway-era outputs because
 --   they didn't change compared to babbage.
 babbageTxOut :: InAnyBabbageEraOnwards (TxOut CtxUTxO) -> TxOut CtxUTxO BabbageEra
@@ -104,3 +119,171 @@ downgradeTxOutRefScript :: ReferenceScript ConwayEra -> ReferenceScript BabbageE
 downgradeTxOutRefScript = \case
   ReferenceScriptNone -> ReferenceScriptNone
   ReferenceScript _era script -> ReferenceScript C.babbageBasedEra script
+
+upgradeTxWitnes :: forall ctx. C.Witness ctx BabbageEra -> C.Witness ctx ConwayEra
+upgradeTxWitnes = \case
+  KeyWitness C.KeyWitnessForSpending -> KeyWitness C.KeyWitnessForSpending
+  KeyWitness C.KeyWitnessForStakeAddr -> KeyWitness C.KeyWitnessForStakeAddr
+  ScriptWitness purpose wit     -> ScriptWitness purpose (updateScriptWitness wit)
+
+updateScriptWitness :: C.ScriptWitness ctx BabbageEra -> C.ScriptWitness ctx ConwayEra
+updateScriptWitness wit =
+  case wit of
+    C.SimpleScriptWitness _ script -> C.SimpleScriptWitness C.SimpleScriptInConway script
+    C.PlutusScriptWitness _ plutusScriptVersion plutusSCript scriptDatum redeemer exUnits ->
+      C.PlutusScriptWitness (plutusScriptLanguageInConwayEra plutusScriptVersion) plutusScriptVersion plutusSCript scriptDatum redeemer exUnits
+
+{-| Bump a cardano-era tx body content to a conway-era tx body content
+-}
+upgradeTxBodyContent :: C.LedgerProtocolParameters ConwayEra -> TxBodyContent BuildTx BabbageEra -> TxBodyContent BuildTx ConwayEra
+upgradeTxBodyContent protParams txb =
+  TxBodyContent
+    { txIns = second (fmap upgradeTxWitnes) <$> txIns txb
+    , txInsCollateral = upgradeTxInsCollateral (txInsCollateral txb)
+    , txInsReference = upgradeTxInsReference (txInsReference txb)
+    , txOuts = upgradeTxOut <$> txOuts txb
+    , txTotalCollateral = upgradeTxTotalCollateral (txTotalCollateral txb)
+    , txReturnCollateral = upgradeTxReturnCollateral (txReturnCollateral txb)
+    , txFee = upgradeTxFee (txFee txb)
+    , txValidityLowerBound = upgradeTxValidityLowerBound (txValidityLowerBound txb)
+    , txValidityUpperBound = upgradeTxValidityUpperBound (txValidityUpperBound txb)
+    , txMetadata = upgradeTxMetadata (txMetadata txb)
+    , txAuxScripts = upgradeTxAuxScripts (txAuxScripts txb)
+    , txExtraKeyWits = upgradeTxExtraKeyWits (txExtraKeyWits txb)
+    , txProtocolParams = C.BuildTxWith (Just protParams)
+    , txWithdrawals = updateTxWithdrawals (txWithdrawals txb)
+    , txCertificates = updateTxCertificates (txCertificates txb)
+    , txUpdateProposal = updateTxUpdateProposal (txUpdateProposal txb)
+    , txMintValue = updateTxMintValue (txMintValue txb)
+    , txScriptValidity = updateTxScriptValidity (txScriptValidity txb)
+    , txProposalProcedures = Nothing
+    , txVotingProcedures = Nothing
+    , txCurrentTreasuryValue = Nothing
+    , txTreasuryDonation = Nothing
+    }
+
+plutusScriptLanguageInConwayEra :: C.PlutusScriptVersion lang -> C.ScriptLanguageInEra lang ConwayEra
+plutusScriptLanguageInConwayEra = \case
+  C.PlutusScriptV1 -> C.PlutusScriptV1InConway
+  C.PlutusScriptV2 -> C.PlutusScriptV2InConway
+  C.PlutusScriptV3 -> C.PlutusScriptV3InConway
+
+upgradeTxInsCollateral :: C.TxInsCollateral BabbageEra -> C.TxInsCollateral ConwayEra
+upgradeTxInsCollateral = \case
+  C.TxInsCollateralNone -> C.TxInsCollateralNone
+  C.TxInsCollateral _ txIns_ -> C.TxInsCollateral C.alonzoBasedEra txIns_
+
+upgradeTxInsReference :: C.TxInsReference BuildTx BabbageEra -> C.TxInsReference BuildTx ConwayEra
+upgradeTxInsReference = \case
+  C.TxInsReferenceNone -> C.TxInsReferenceNone
+  C.TxInsReference _ txIns_ -> C.TxInsReference C.babbageBasedEra txIns_
+
+upgradeTxOut :: TxOut ctx BabbageEra -> TxOut ctx ConwayEra
+upgradeTxOut txOut =
+  let (addr, vl, dat, ref) = L.view L._TxOut txOut
+  in TxOut
+      (C.fromShelleyAddr C.shelleyBasedEra $ C.toShelleyAddr addr)
+      (C.TxOutValueShelleyBased C.shelleyBasedEra $ C.toMaryValue $ C.txOutValueToValue vl)
+      (upgradeTxOutDatum dat)
+      (upgradeTxOutRefScript ref)
+
+upgradeTxOutDatum :: TxOutDatum ctx BabbageEra -> TxOutDatum ctx ConwayEra
+upgradeTxOutDatum = \case
+  TxOutDatumNone -> TxOutDatumNone
+  TxOutDatumHash _era hash -> TxOutDatumHash C.alonzoBasedEra hash
+  TxOutDatumInline _era dat -> TxOutDatumInline C.babbageBasedEra dat
+
+upgradeTxOutRefScript :: ReferenceScript BabbageEra -> ReferenceScript ConwayEra
+upgradeTxOutRefScript = \case
+  ReferenceScriptNone -> ReferenceScriptNone
+  ReferenceScript _era script -> ReferenceScript C.babbageBasedEra script
+
+upgradeTxTotalCollateral :: C.TxTotalCollateral BabbageEra -> C.TxTotalCollateral ConwayEra
+upgradeTxTotalCollateral = \case
+  C.TxTotalCollateralNone -> C.TxTotalCollateralNone
+  C.TxTotalCollateral _ coin -> C.TxTotalCollateral BabbageEraOnwardsConway coin
+
+upgradeTxReturnCollateral :: C.TxReturnCollateral C.CtxTx BabbageEra -> C.TxReturnCollateral C.CtxTx ConwayEra
+upgradeTxReturnCollateral = \case
+  C.TxReturnCollateralNone -> C.TxReturnCollateralNone
+  C.TxReturnCollateral _ txOut -> C.TxReturnCollateral BabbageEraOnwardsConway (upgradeTxOut txOut)
+
+upgradeTxFee :: C.TxFee BabbageEra -> C.TxFee ConwayEra
+upgradeTxFee = \case
+  C.TxFeeExplicit _ coin -> C.TxFeeExplicit C.shelleyBasedEra coin
+
+upgradeTxValidityLowerBound :: C.TxValidityLowerBound BabbageEra -> C.TxValidityLowerBound ConwayEra
+upgradeTxValidityLowerBound = \case
+  C.TxValidityNoLowerBound -> C.TxValidityNoLowerBound
+  C.TxValidityLowerBound _era slotNo -> C.TxValidityLowerBound C.allegraBasedEra slotNo
+
+upgradeTxValidityUpperBound :: C.TxValidityUpperBound BabbageEra -> C.TxValidityUpperBound ConwayEra
+upgradeTxValidityUpperBound = \case
+  C.TxValidityUpperBound _era slotNo -> C.TxValidityUpperBound C.shelleyBasedEra slotNo
+
+upgradeTxMetadata :: C.TxMetadataInEra BabbageEra -> C.TxMetadataInEra ConwayEra
+upgradeTxMetadata = \case
+  C.TxMetadataNone -> C.TxMetadataNone
+  C.TxMetadataInEra _ md -> C.TxMetadataInEra C.shelleyBasedEra md
+
+upgradeTxAuxScripts :: C.TxAuxScripts BabbageEra -> C.TxAuxScripts ConwayEra
+upgradeTxAuxScripts = \case
+  C.TxAuxScriptsNone -> C.TxAuxScriptsNone
+  C.TxAuxScripts _era scripts -> C.TxAuxScripts C.allegraBasedEra (upgradeScriptInEra <$> scripts)
+
+upgradeScriptInEra :: C.ScriptInEra BabbageEra -> C.ScriptInEra ConwayEra
+upgradeScriptInEra = \case
+  C.ScriptInEra lang script -> C.ScriptInEra (updateScriptLanguageInEra lang) script
+
+updateScriptLanguageInEra :: C.ScriptLanguageInEra lang BabbageEra -> C.ScriptLanguageInEra lang ConwayEra
+updateScriptLanguageInEra = \case
+  C.SimpleScriptInBabbage -> C.SimpleScriptInConway
+  C.PlutusScriptV1InBabbage -> C.PlutusScriptV1InConway
+  C.PlutusScriptV2InBabbage -> C.PlutusScriptV2InConway
+
+upgradeTxExtraKeyWits :: C.TxExtraKeyWitnesses BabbageEra -> C.TxExtraKeyWitnesses ConwayEra
+upgradeTxExtraKeyWits = \case
+  C.TxExtraKeyWitnessesNone -> C.TxExtraKeyWitnessesNone
+  C.TxExtraKeyWitnesses _ keys -> C.TxExtraKeyWitnesses C.alonzoBasedEra keys
+
+updateTxWithdrawals :: C.TxWithdrawals BuildTx BabbageEra -> C.TxWithdrawals BuildTx ConwayEra
+updateTxWithdrawals = \case
+  C.TxWithdrawalsNone -> C.TxWithdrawalsNone
+  C.TxWithdrawals _era withdrawals -> C.TxWithdrawals C.shelleyBasedEra (updateWithdrawal <$> withdrawals)
+
+updateWithdrawal :: (StakeAddress, Coin, BuildTxWith BuildTx (Witness WitCtxStake BabbageEra)) -> (StakeAddress, Coin, BuildTxWith BuildTx (Witness WitCtxStake ConwayEra))
+updateWithdrawal (addr, coin, btx) =
+  let btx' = fmap upgradeTxWitnes btx
+  in (addr, coin, btx')
+
+updateTxCertificates :: C.TxCertificates BuildTx BabbageEra -> C.TxCertificates BuildTx ConwayEra
+updateTxCertificates = \case
+  C.TxCertificatesNone -> C.TxCertificatesNone
+  C.TxCertificates _era certs buildWith -> C.TxCertificates C.shelleyBasedEra (upgradeCertificate <$> certs) (fmap upgradeTxWitnes <$> buildWith)
+
+upgradeCertificate :: C.Certificate BabbageEra -> C.Certificate ConwayEra
+upgradeCertificate = \case
+  C.ShelleyRelatedCertificate _era cert -> C.ConwayCertificate C.conwayBasedEra (upgradeTxCert cert)
+  C.ConwayCertificate _era _cert -> error "Impossible: Conway certificate in babbage era"
+
+upgradeTxCert :: ShelleyTxCert (C.ShelleyLedgerEra BabbageEra) -> ConwayTxCert (C.ShelleyLedgerEra ConwayEra)
+upgradeTxCert = \case
+  ShelleyTxCertDelegCert cert -> ConwayTxCertDeleg (L.fromShelleyDelegCert cert)
+  ShelleyTxCertPool cert      -> ConwayTxCertPool cert
+  ShelleyTxCertGenesisDeleg{} -> error "Convx.Eras.upgradeTxCert Not supported: ShelleyTxCertGenesisDeleg"
+  ShelleyTxCertMir{}          -> error "Convx.Eras.upgradeTxCert Not supported: ShelleyTxCertMir"
+
+updateTxUpdateProposal :: C.TxUpdateProposal BabbageEra -> C.TxUpdateProposal ConwayEra
+updateTxUpdateProposal = \case
+  C.TxUpdateProposalNone -> C.TxUpdateProposalNone
+  C.TxUpdateProposal{} -> error "Convx.Eras.updateTxUpdateProposal Not supported: TxUpdateProposal"
+
+updateTxMintValue :: C.TxMintValue BuildTx BabbageEra -> C.TxMintValue BuildTx ConwayEra
+updateTxMintValue = \case
+  C.TxMintNone -> C.TxMintNone
+  C.TxMintValue _era value wits -> C.TxMintValue C.maryBasedEra value (fmap (fmap updateScriptWitness) wits)
+
+updateTxScriptValidity :: C.TxScriptValidity BabbageEra -> C.TxScriptValidity ConwayEra
+updateTxScriptValidity = \case
+  C.TxScriptValidityNone -> C.TxScriptValidityNone
+  C.TxScriptValidity _ v -> C.TxScriptValidity C.alonzoBasedEra v

--- a/src/base/lib/Convex/Eras.hs
+++ b/src/base/lib/Convex/Eras.hs
@@ -8,6 +8,7 @@ module Convex.Eras(
   inAnyBabbageEraOnwardsBabbage,
   inAnyBabbageEraOnwardsConway,
   toInAnyCardanoEra,
+  fromInAnyCardanoEra,
   -- * Downgrades to babbage era
   babbageProtocolParams,
   babbageTxOut,
@@ -17,7 +18,8 @@ module Convex.Eras(
 
 import           Cardano.Api              (BabbageEra, BabbageEraOnwards (..),
                                            ConwayEra)
-import           Cardano.Api.Shelley      (CtxUTxO, InAnyCardanoEra (..),
+import           Cardano.Api.Shelley      (CardanoEra (..), CtxUTxO,
+                                           InAnyCardanoEra (..),
                                            LedgerProtocolParameters (..),
                                            ReferenceScript (..), TxOut (..),
                                            TxOutDatum (..), UTxO (..))
@@ -41,6 +43,13 @@ toInAnyCardanoEra :: InAnyBabbageEraOnwards thing -> InAnyCardanoEra thing
 toInAnyCardanoEra = \case
   InAnyBabbageEraOnwards BabbageEraOnwardsBabbage thing -> C.inAnyCardanoEra C.cardanoEra thing
   InAnyBabbageEraOnwards BabbageEraOnwardsConway thing -> C.inAnyCardanoEra C.cardanoEra thing
+
+-- | Strengthen 'InAnyCardanoEra' to 'InAnyBabbageEraOnwards'
+fromInAnyCardanoEra :: InAnyCardanoEra thing -> Maybe (InAnyBabbageEraOnwards thing)
+fromInAnyCardanoEra = \case
+  InAnyCardanoEra BabbageEra thing -> Just (InAnyBabbageEraOnwards BabbageEraOnwardsBabbage thing)
+  InAnyCardanoEra ConwayEra thing -> Just (InAnyBabbageEraOnwards BabbageEraOnwardsConway thing)
+  _ -> Nothing
 
 -- | Constructor for 'InAnyBabbageEraOnwards'
 inAnyBabbageEraOnwards :: Typeable era => BabbageEraOnwards era -> thing era -> InAnyBabbageEraOnwards thing

--- a/src/base/lib/Convex/Eras.hs
+++ b/src/base/lib/Convex/Eras.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE GADTs      #-}
+{-# LANGUAGE LambdaCase #-}
+{-| Utilities for dealing with eras
+-}
+module Convex.Eras(
+  InAnyBabbageEraOnwards(..),
+  inAnyBabbageEraOnwards,
+  inAnyBabbageEraOnwardsBabbage,
+  inAnyBabbageEraOnwardsConway,
+  -- * Downgrades to babbage era
+  babbageProtocolParams,
+  babbageTxOut,
+  babbageUTxO,
+  downgradeTxOut
+) where
+
+import           Cardano.Api              (BabbageEra, BabbageEraOnwards (..),
+                                           ConwayEra)
+import           Cardano.Api.Shelley      (CtxUTxO,
+                                           LedgerProtocolParameters (..),
+                                           ReferenceScript (..), TxOut (..),
+                                           TxOutDatum (..), UTxO (..))
+import qualified Cardano.Api.Shelley      as C
+import qualified Cardano.Ledger.Core      as PParams
+import qualified Control.Lens             as L
+import qualified Convex.CardanoApi.Lenses as L
+import           Data.Typeable            (Typeable)
+
+-- | A value with unknown Babbage-onwards era type.
+--   Similar to Cardano.Api.Eras.Core but for modern eras.
+data InAnyBabbageEraOnwards thing where
+  InAnyBabbageEraOnwards
+    :: Typeable era
+    => BabbageEraOnwards era
+    -> thing era
+    -> InAnyBabbageEraOnwards thing
+
+-- | Constructor for 'InAnyBabbageEraOnwards'
+inAnyBabbageEraOnwards :: Typeable era => BabbageEraOnwards era -> thing era -> InAnyBabbageEraOnwards thing
+inAnyBabbageEraOnwards = InAnyBabbageEraOnwards
+
+-- | 'inAnyBabbageEraOnwards' specialized to babbage
+inAnyBabbageEraOnwardsBabbage :: thing BabbageEra -> InAnyBabbageEraOnwards thing
+inAnyBabbageEraOnwardsBabbage = InAnyBabbageEraOnwards BabbageEraOnwardsBabbage
+
+-- | 'inAnyBabbageEraOnwards' specialized to conway
+inAnyBabbageEraOnwardsConway :: thing ConwayEra -> InAnyBabbageEraOnwards thing
+inAnyBabbageEraOnwardsConway = InAnyBabbageEraOnwards BabbageEraOnwardsConway
+
+-- | Babbage-era protocol parameters
+babbageProtocolParams :: InAnyBabbageEraOnwards LedgerProtocolParameters -> LedgerProtocolParameters BabbageEra
+babbageProtocolParams = \case
+  InAnyBabbageEraOnwards BabbageEraOnwardsBabbage p -> p
+  InAnyBabbageEraOnwards BabbageEraOnwardsConway (LedgerProtocolParameters p)  ->
+    LedgerProtocolParameters $ PParams.downgradePParams () p
+
+-- | Babbage-era UTxO
+babbageUTxO :: InAnyBabbageEraOnwards C.UTxO -> C.UTxO BabbageEra
+babbageUTxO = \case
+  InAnyBabbageEraOnwards BabbageEraOnwardsBabbage p -> p
+  InAnyBabbageEraOnwards BabbageEraOnwardsConway (UTxO m) ->
+    UTxO $ fmap downgradeTxOut m
+
+-- | Babbage-era tx outputs. We can always downgrade conway-era outputs because
+--   they didn't change compared to babbage.
+babbageTxOut :: InAnyBabbageEraOnwards (TxOut CtxUTxO) -> TxOut CtxUTxO BabbageEra
+babbageTxOut = \case
+  InAnyBabbageEraOnwards BabbageEraOnwardsBabbage o -> o
+  InAnyBabbageEraOnwards BabbageEraOnwardsConway txOut ->
+    downgradeTxOut txOut
+
+downgradeTxOut :: TxOut CtxUTxO ConwayEra -> TxOut CtxUTxO BabbageEra
+downgradeTxOut txOut =
+  let (addr, vl, dat, ref) = L.view L._TxOut txOut
+  in TxOut
+      (C.fromShelleyAddr C.shelleyBasedEra $ C.toShelleyAddr addr)
+      (C.TxOutValueShelleyBased C.shelleyBasedEra $ C.toMaryValue $ C.txOutValueToValue vl)
+      (downgradeTxOutDatum dat)
+      (downgradeTxOutRefScript ref)
+
+downgradeTxOutDatum :: TxOutDatum CtxUTxO ConwayEra -> TxOutDatum CtxUTxO BabbageEra
+downgradeTxOutDatum = \case
+  TxOutDatumNone -> TxOutDatumNone
+  TxOutDatumHash _era hash -> TxOutDatumHash C.alonzoBasedEra hash
+  TxOutDatumInline _era dat -> TxOutDatumInline C.babbageBasedEra dat
+
+downgradeTxOutRefScript :: ReferenceScript ConwayEra -> ReferenceScript BabbageEra
+downgradeTxOutRefScript = \case
+  ReferenceScriptNone -> ReferenceScriptNone
+  ReferenceScript _era script -> ReferenceScript C.babbageBasedEra script

--- a/src/base/lib/Convex/Eras.hs
+++ b/src/base/lib/Convex/Eras.hs
@@ -7,6 +7,7 @@ module Convex.Eras(
   inAnyBabbageEraOnwards,
   inAnyBabbageEraOnwardsBabbage,
   inAnyBabbageEraOnwardsConway,
+  toInAnyCardanoEra,
   -- * Downgrades to babbage era
   babbageProtocolParams,
   babbageTxOut,
@@ -16,7 +17,7 @@ module Convex.Eras(
 
 import           Cardano.Api              (BabbageEra, BabbageEraOnwards (..),
                                            ConwayEra)
-import           Cardano.Api.Shelley      (CtxUTxO,
+import           Cardano.Api.Shelley      (CtxUTxO, InAnyCardanoEra (..),
                                            LedgerProtocolParameters (..),
                                            ReferenceScript (..), TxOut (..),
                                            TxOutDatum (..), UTxO (..))
@@ -34,6 +35,12 @@ data InAnyBabbageEraOnwards thing where
     => BabbageEraOnwards era
     -> thing era
     -> InAnyBabbageEraOnwards thing
+
+-- | Relax 'InAnyBabbageEraOnwards' to 'InAnyCardanoEra'
+toInAnyCardanoEra :: InAnyBabbageEraOnwards thing -> InAnyCardanoEra thing
+toInAnyCardanoEra = \case
+  InAnyBabbageEraOnwards BabbageEraOnwardsBabbage thing -> C.inAnyCardanoEra C.cardanoEra thing
+  InAnyBabbageEraOnwards BabbageEraOnwardsConway thing -> C.inAnyCardanoEra C.cardanoEra thing
 
 -- | Constructor for 'InAnyBabbageEraOnwards'
 inAnyBabbageEraOnwards :: Typeable era => BabbageEraOnwards era -> thing era -> InAnyBabbageEraOnwards thing

--- a/src/base/lib/Convex/NodeQueries.hs
+++ b/src/base/lib/Convex/NodeQueries.hs
@@ -1,51 +1,85 @@
-{-# LANGUAGE GADTs      #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE RankNTypes         #-}
+{-# LANGUAGE ViewPatterns       #-}
 {-| Conveniences for working with a local @cardano-node@
 -}
 module Convex.NodeQueries(
+  -- * Local node connect info
   loadConnectInfo,
+  localNodeConnectInfo,
+
+  -- * Queries
   queryEraHistory,
+  tryQueryEraHistory,
   querySystemStart,
-  queryLocalState,
+  tryQuerySystemStart,
   queryTip,
+  tryQueryTip,
   queryProtocolParameters,
+  tryQueryProtocolParameters,
+  queryTipBlock,
+  tryQueryTipBlock,
+  queryEra,
+  tryQueryEra,
   queryStakePools,
-  queryStakeAddresses
+  tryQueryStakePools,
+  queryStakeAddresses,
+  tryQueryStakeAddresses
 ) where
 
-import           Cardano.Api                                        (ChainPoint,
+
+import           Cardano.Api                                        (BlockNo,
                                                                      ConsensusModeParams (..),
-                                                                     Env (..),
+                                                                     Env,
                                                                      EpochSlots (..),
-                                                                     EraHistory,
+                                                                     EraHistory (..),
                                                                      InitialLedgerStateError,
                                                                      LocalNodeConnectInfo (..),
-                                                                     NetworkId (Mainnet, Testnet),
+                                                                     NetworkId (..),
                                                                      NetworkMagic (..),
-                                                                     Quantity,
-                                                                     SystemStart,
-                                                                     envSecurityParam)
-import qualified Cardano.Api                                        as CAPI
-import           Cardano.Api.Shelley                                (PoolId,
+                                                                     Quantity (..),
                                                                      StakeAddress,
-                                                                     StakeCredential)
+                                                                     StakeCredential,
+                                                                     envLedgerConfig,
+                                                                     envSecurityParam)
+import qualified Cardano.Api                                        as C
+import           Cardano.Api.Shelley                                (LedgerProtocolParameters (..),
+                                                                     PoolId)
 import qualified Cardano.Chain.Genesis
 import           Cardano.Crypto                                     (RequiresNetworkMagic (..),
                                                                      getProtocolMagic)
-import           Cardano.Ledger.Core                                (PParams)
-import           Control.Monad.Except                               (MonadError,
+import           Cardano.Ledger.Coin                                (Coin (..))
+import           Cardano.Slotting.Slot                              (WithOrigin)
+import           Cardano.Slotting.Time                              (SystemStart)
+import           Control.Exception                                  (Exception,
+                                                                     throw)
+import           Control.Monad.Error.Class                          (MonadError (..),
                                                                      throwError)
+import           Control.Monad.Except                               (ExceptT,
+                                                                     runExceptT)
 import           Control.Monad.IO.Class                             (MonadIO (..))
-import           Control.Monad.Trans.Except                         (runExceptT)
+import           Control.Monad.Reader                               (ReaderT,
+                                                                     runReaderT)
+import           Control.Monad.Reader.Class                         (MonadReader,
+                                                                     ask)
+import           Convex.Eras                                        (InAnyBabbageEraOnwards (..))
+import qualified Convex.Eras                                        as Eras
+import           Convex.MonadLog                                    (MonadLog (..),
+                                                                     MonadLogIgnoreT (..),
+                                                                     logWarnS)
 import           Data.Bifunctor                                     (Bifunctor (..))
 import           Data.Map                                           (Map)
 import           Data.Set                                           (Set)
 import           Data.SOP.Strict                                    (NP ((:*)))
+import           Data.Word                                          (Word64)
 import qualified Ouroboros.Consensus.Cardano.CanHardFork            as Consensus
 import qualified Ouroboros.Consensus.HardFork.Combinator            as Consensus
+import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
 import qualified Ouroboros.Consensus.HardFork.Combinator.AcrossEras as HFC
 import qualified Ouroboros.Consensus.HardFork.Combinator.Basics     as HFC
-import           Ouroboros.Consensus.Shelley.Eras                   (StandardBabbage)
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type    as T
 
 {-| Load the node config file and create 'LocalNodeConnectInfo' and 'Env' values that can be used to talk to the node.
@@ -58,7 +92,7 @@ loadConnectInfo ::
   -- ^ Node socket
   -> m (LocalNodeConnectInfo, Env)
 loadConnectInfo nodeConfigFilePath socketPath = do
-  (env, _) <- liftIO (runExceptT (CAPI.initialLedgerState (CAPI.File nodeConfigFilePath))) >>= either throwError pure
+  (env, _) <- liftIO (runExceptT (C.initialLedgerState (C.File nodeConfigFilePath))) >>= either throwError pure
 
   -- Derive the NetworkId as described in network-magic.md from the
   -- cardano-ledger-specs repo.
@@ -76,63 +110,186 @@ loadConnectInfo nodeConfigFilePath socketPath = do
         RequiresNoMagic -> Mainnet
         RequiresMagic   -> Testnet (NetworkMagic networkMagic)
 
-      cardanoModeParams = CardanoModeParams . EpochSlots $ 10 * envSecurityParam env
+      cardanoModeParams_ = CardanoModeParams . EpochSlots $ 10 * envSecurityParam env
 
   -- Connect to the node.
   let connectInfo :: LocalNodeConnectInfo
       connectInfo =
           LocalNodeConnectInfo {
-            localConsensusModeParams = cardanoModeParams,
+            localConsensusModeParams = cardanoModeParams_,
             localNodeNetworkId       = networkId,
-            localNodeSocketPath      = CAPI.File socketPath
+            localNodeSocketPath      = C.File socketPath
           }
   pure (connectInfo, env)
 
--- | Get the system start from the local cardano node
-querySystemStart :: LocalNodeConnectInfo -> IO SystemStart
-querySystemStart = queryLocalState CAPI.QuerySystemStart
+{-| 'C.LocalNodeConnectInfo' with default values for consensus mode params.
+Use 'loadConnectInfo' to load the consensus mode params from the node config.
+-}
+localNodeConnectInfo :: NetworkId -> FilePath -> C.LocalNodeConnectInfo
+localNodeConnectInfo localNodeNetworkId (C.File -> localNodeSocketPath) =
+  C.LocalNodeConnectInfo
+    { localConsensusModeParams = cardanoModeParams
+    , localNodeNetworkId
+    , localNodeSocketPath
+    }
 
--- | Get the era history from the local cardano node
-queryEraHistory :: LocalNodeConnectInfo -> IO EraHistory
-queryEraHistory = queryLocalState CAPI.QueryEraHistory
+cardanoModeParams :: C.ConsensusModeParams
+cardanoModeParams = C.CardanoModeParams $ C.EpochSlots defaultByronEpochSlots
+ where
+  -- NOTE(AB): extracted from Parsers in cardano-cli, this is needed to run in 'cardanoMode' which
+  -- is the default for cardano-cli
+  defaultByronEpochSlots = 21600 :: Word64
+
+data QueryError
+  = QueryAcquireError String
+  | QueryEraMismatchError EraMismatch
+  | QueryUnsupportedEra C.AnyCardanoEra
+  deriving (Eq, Show)
+
+newtype QueryException = QueryException QueryError
+  deriving newtype (Eq, Show)
+
+instance Exception QueryException
+
+-- | Get the 'EraHistory' from the node
+queryEraHistory :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => m EraHistory
+queryEraHistory = runQuery C.QueryEraHistory
+
+-- | Get the 'EraHistory' from the node
+tryQueryEraHistory :: LocalNodeConnectInfo -> IO EraHistory
+tryQueryEraHistory = tryRunQuery queryEraHistory
+
+-- | Get the 'SystemStart' from the node
+querySystemStart :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => m SystemStart
+querySystemStart = runQuery C.QuerySystemStart
+
+-- | Get the 'SystemStart' from the node
+tryQuerySystemStart :: LocalNodeConnectInfo -> IO SystemStart
+tryQuerySystemStart = tryRunQuery querySystemStart
+
+queryTipBlock :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => m (WithOrigin BlockNo)
+queryTipBlock = runQuery C.QueryChainBlockNo
+
+tryQueryTipBlock :: LocalNodeConnectInfo -> IO (WithOrigin BlockNo)
+tryQueryTipBlock = tryRunQuery queryTipBlock
+
+queryEra :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => m C.AnyCardanoEra
+queryEra = runQuery C.QueryCurrentEra
+
+tryQueryEra :: LocalNodeConnectInfo -> IO C.AnyCardanoEra
+tryQueryEra = tryRunQuery queryEra
 
 -- | Get the tip from the local cardano node
-queryTip :: LocalNodeConnectInfo -> IO ChainPoint
-queryTip = queryLocalState CAPI.QueryChainPoint
+queryTip :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => m C.ChainPoint
+queryTip = runQuery C.QueryChainPoint
 
-queryStakePools :: LocalNodeConnectInfo -> IO (Set PoolId)
-queryStakePools connectInfo = do
-  result <- queryLocalState
-              (CAPI.QueryInEra (CAPI.QueryInShelleyBasedEra CAPI.ShelleyBasedEraBabbage CAPI.QueryStakePools))
-              connectInfo
+tryQueryTip :: LocalNodeConnectInfo -> IO C.ChainPoint
+tryQueryTip = tryRunQuery queryTip
+
+{-| Query the node for the current era.
+Fails with 'UnsupportedEra' if the current era is not one of (Babbage, Conway)
+-}
+getSupportedEra :: forall m.
+  ( MonadIO m
+  , MonadReader LocalNodeConnectInfo m
+  , MonadError QueryError m
+  ) =>
+  m (InAnyBabbageEraOnwards C.BabbageEraOnwards)
+getSupportedEra = do
+  connectInfo <- ask
+  era <- liftIO (runExceptT $ C.queryNodeLocalState connectInfo T.VolatileTip C.QueryCurrentEra) >>= either (throwError . QueryAcquireError . show) pure
+  case era of
+    C.AnyCardanoEra C.BabbageEra -> pure $ Eras.inAnyBabbageEraOnwardsBabbage C.BabbageEraOnwardsBabbage
+    C.AnyCardanoEra C.ConwayEra  -> pure $ Eras.inAnyBabbageEraOnwardsConway C.BabbageEraOnwardsConway
+    otherEra -> throwError (QueryUnsupportedEra otherEra)
+
+tryRunQuery :: ReaderT LocalNodeConnectInfo (MonadLogIgnoreT (ExceptT QueryError IO)) a -> LocalNodeConnectInfo -> IO a
+tryRunQuery action connectInfo = runExceptT (runMonadLogIgnoreT (runReaderT action connectInfo)) >>= \case
+  Left err -> throw (QueryException err)
+  Right k -> pure k
+
+runQuery :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => C.QueryInMode a -> m a
+runQuery qry = do
+  info <- ask
+  result <- liftIO (runExceptT $ C.queryNodeLocalState info T.VolatileTip qry)
   case result of
     Left err -> do
-      fail ("queryStakePools: failed with: " <> show err)
-    Right k -> pure k
+      let msg = "runQuery: Query failed: " <> show err
+      logWarnS msg
+      throwError $ QueryAcquireError $ show err
+    Right result' -> do
+      pure result'
 
-queryStakeAddresses :: LocalNodeConnectInfo -> Set StakeCredential -> NetworkId -> IO (Map StakeAddress Quantity, Map StakeAddress PoolId)
-queryStakeAddresses info creds nid = do
-  result <- queryLocalState
-              (CAPI.QueryInEra (CAPI.QueryInShelleyBasedEra CAPI.ShelleyBasedEraBabbage (CAPI.QueryStakeAddresses creds nid)))
-              info
-  case result of
-    Left err -> do
-      fail ("queryStakeAddresses: failed with: " <> show err)
-    Right k -> pure (first (fmap CAPI.lovelaceToQuantity) k)
+{-| An query that returns an era-specific value wrapped in an era-agnostic type
+-}
+data QueryWithHandler a =
+  forall b. QueryWithHandler
+    { qryQuery   :: C.QueryInMode (Either EraMismatch b) -- ^ Era-specific query returning value of type b
+    , qryHandler :: b -> a -- ^ Era-agnostic return type @a@
+    }
 
--- | Run a local state query on the local cardano node, using the volatile tip
-queryLocalState :: CAPI.QueryInMode b -> LocalNodeConnectInfo -> IO b
-queryLocalState query connectInfo = do
-  runExceptT (CAPI.queryNodeLocalState connectInfo T.VolatileTip query) >>= \case
-    Left err -> do
-      fail ("queryLocalState: Failed with " <> show err)
-    Right result -> pure result
+runQuery' :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => (InAnyBabbageEraOnwards C.BabbageEraOnwards -> QueryWithHandler b) -> m b
+runQuery' qry = do
+  era <- getSupportedEra
+  case qry era of
+    QueryWithHandler{qryQuery, qryHandler} ->
+      runQuery qryQuery >>= \case
+        Left err -> do
+          -- *should* not happen as we pass the era to the handler to construct the right query
+          -- However, if the HF happens at exactly the moment between "asking for era" and "submitting query"
+          -- then we will still fail
+          let msg = "runQuery': Era mismatch: " <> show err
+          logWarnS msg
+          throwError $ QueryEraMismatchError err
+        Right result' -> pure $ qryHandler result'
 
--- | Get the protocol parameters from the local cardano node
-queryProtocolParameters :: LocalNodeConnectInfo -> IO (PParams StandardBabbage)
-queryProtocolParameters connectInfo = do
-  result <- queryLocalState (CAPI.QueryInEra (CAPI.QueryInShelleyBasedEra CAPI.ShelleyBasedEraBabbage CAPI.QueryProtocolParameters)) connectInfo
-  case result of
-    Left err -> do
-      fail ("queryProtocolParameters: failed with: " <> show err)
-    Right x -> pure x
+queryProtocolParameters :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => m (InAnyBabbageEraOnwards LedgerProtocolParameters)
+queryProtocolParameters = runQuery' $ \case
+  InAnyBabbageEraOnwards C.BabbageEraOnwardsBabbage C.BabbageEraOnwardsBabbage ->
+    QueryWithHandler
+      { qryQuery   = C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraBabbage C.QueryProtocolParameters)
+      , qryHandler = Eras.inAnyBabbageEraOnwardsBabbage . LedgerProtocolParameters
+      }
+  InAnyBabbageEraOnwards C.BabbageEraOnwardsConway C.BabbageEraOnwardsConway ->
+    QueryWithHandler
+      { qryQuery   = C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraConway C.QueryProtocolParameters)
+      , qryHandler = Eras.inAnyBabbageEraOnwardsConway . LedgerProtocolParameters
+      }
+
+tryQueryProtocolParameters :: LocalNodeConnectInfo -> IO (InAnyBabbageEraOnwards LedgerProtocolParameters)
+tryQueryProtocolParameters = tryRunQuery queryProtocolParameters
+
+queryStakePools :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => m (Set PoolId)
+queryStakePools = runQuery' $ \case
+  InAnyBabbageEraOnwards C.BabbageEraOnwardsBabbage C.BabbageEraOnwardsBabbage ->
+    QueryWithHandler
+      { qryQuery   = C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraBabbage C.QueryStakePools)
+      , qryHandler = id
+      }
+  InAnyBabbageEraOnwards C.BabbageEraOnwardsConway C.BabbageEraOnwardsConway ->
+    QueryWithHandler
+      { qryQuery   = C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraConway C.QueryStakePools)
+      , qryHandler = id
+      }
+
+tryQueryStakePools :: LocalNodeConnectInfo -> IO (Set PoolId)
+tryQueryStakePools = tryRunQuery queryStakePools
+
+queryStakeAddresses :: (MonadIO m, MonadLog m, MonadReader LocalNodeConnectInfo m, MonadError QueryError m) => Set StakeCredential -> m (Map StakeAddress Quantity, Map StakeAddress PoolId)
+queryStakeAddresses creds = do
+  LocalNodeConnectInfo{localNodeNetworkId} <- ask
+  let coinToQuantity (Coin i) = Quantity i
+  runQuery' $ \case
+    InAnyBabbageEraOnwards C.BabbageEraOnwardsBabbage C.BabbageEraOnwardsBabbage ->
+      QueryWithHandler
+        { qryQuery   = C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraBabbage (C.QueryStakeAddresses creds localNodeNetworkId))
+        , qryHandler = first (fmap coinToQuantity)
+        }
+    InAnyBabbageEraOnwards C.BabbageEraOnwardsConway C.BabbageEraOnwardsConway ->
+      QueryWithHandler
+        { qryQuery   = C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraConway (C.QueryStakeAddresses creds localNodeNetworkId))
+        , qryHandler = first (fmap coinToQuantity)
+        }
+
+tryQueryStakeAddresses :: LocalNodeConnectInfo -> Set StakeCredential -> IO (Map StakeAddress Quantity, Map StakeAddress PoolId)
+tryQueryStakeAddresses connectInfo creds = tryRunQuery (queryStakeAddresses creds) connectInfo

--- a/src/base/lib/Convex/Utxos.hs
+++ b/src/base/lib/Convex/Utxos.hs
@@ -222,8 +222,15 @@ makePrisms ''UtxoSet
 
 {-| Convert a @cardano-api@ 'UTxO BabbageEra' to a utxo set
 -}
-fromApiUtxo :: C.IsCardanoEra era => a -> UTxO era -> UtxoSet C.CtxUTxO a
-fromApiUtxo v (UTxO utxoSet) = UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
+fromApiUtxo :: a -> C.InAnyCardanoEra UTxO -> UtxoSet C.CtxUTxO a
+fromApiUtxo v = \case
+  C.InAnyCardanoEra C.ByronEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
+  C.InAnyCardanoEra C.AllegraEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
+  C.InAnyCardanoEra C.MaryEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
+  C.InAnyCardanoEra C.ShelleyEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
+  C.InAnyCardanoEra C.AlonzoEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
+  C.InAnyCardanoEra C.BabbageEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
+  C.InAnyCardanoEra C.ConwayEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
 
 {-| Convert a utxo set to a @cardano-api@ 'UTxO BabbageEra'
 -}

--- a/src/coin-selection/convex-coin-selection.cabal
+++ b/src/coin-selection/convex-coin-selection.cabal
@@ -45,10 +45,8 @@ library
       convex-mockchain,
       convex-base,
       convex-optics,
-      convex-node-client,
       convex-wallet,
       data-default,
-      QuickCheck,
       servant-client,
       text
 
@@ -56,11 +54,11 @@ library
     build-depends:
       cardano-api,
       cardano-ledger-core -any,
+      cardano-ledger-conway,
       cardano-ledger-shelley,
       cardano-slotting,
       transformers,
-      mtl,
-      either-result
+      mtl
 
 test-suite convex-coin-selection-test
   import: lang

--- a/src/coin-selection/lib/Convex/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection.hs
@@ -289,7 +289,7 @@ balanceTransactionBody
 -}
 refScriptsFeeBabbageTxnInConway :: C.TxBody BabbageEra -> UTxO BabbageEra -> C.LedgerProtocolParameters C.ConwayEra -> Coin
 refScriptsFeeBabbageTxnInConway tx_body tx_utxo params =
-  let refScriptSize = C.getReferenceInputsSizeForTxIds C.BabbageEraOnwardsBabbage (C.toLedgerUTxO C.ShelleyBasedEraBabbage tx_utxo) (referenceScriptInputs $ C.getTxBodyContent tx_body)
+  let refScriptSize = C.getReferenceInputsSizeForTxIds C.BabbageEraOnwardsBabbage (C.toLedgerUTxO C.ShelleyBasedEraBabbage tx_utxo) (spentTxIns $ C.getTxBodyContent tx_body)
       refScriptCostPerByte = Ledger.unboundRational (C.unLedgerProtocolParameters params ^. Ledger.ppMinFeeRefScriptCostPerByteL)
       refScriptsFee = Ledger.tierRefScriptFee multiplier sizeIncrement refScriptCostPerByte refScriptSize
 

--- a/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
@@ -26,6 +26,7 @@ import           Convex.CoinSelection      (BalanceTxError,
                                             ChangeOutputPosition (TrailingChange),
                                             TxBalancingMessage)
 import qualified Convex.CoinSelection      as CoinSelection
+import qualified Convex.Eras               as Eras
 import qualified Convex.MockChain          as MockChain
 import qualified Convex.MockChain.Defaults as Defaults
 import           Convex.Wallet             (Wallet)
@@ -102,13 +103,13 @@ paymentTo wFrom wTo = do
 {-| Pay 100 Ada from one of the seed addresses to an @Operator@
 -}
 payToOperator :: (MonadMockchain m, MonadError (BalanceTxError CoinSelection.ERA) m) => Tracer m TxBalancingMessage -> Wallet -> Operator k -> m (Either SendTxFailed (C.Tx C.BabbageEra))
-payToOperator dbg wFrom = payToOperator' dbg (C.lovelaceToValue 100_000_000) wFrom
+payToOperator dbg = payToOperator' dbg (C.lovelaceToValue 100_000_000)
 
 {-| Pay some Ada from one of the seed addresses to an @Operator@
 -}
 payToOperator' :: (MonadMockchain m, MonadError (BalanceTxError CoinSelection.ERA) m) => Tracer m TxBalancingMessage -> Value -> Wallet -> Operator k -> m (Either SendTxFailed (C.Tx C.BabbageEra))
 payToOperator' dbg value wFrom Operator{oPaymentKey} = do
-  p <- queryProtocolParameters
+  p <- Eras.babbageProtocolParams <$> queryProtocolParameters
   let addr =
         C.makeShelleyAddressInEra C.ShelleyBasedEraBabbage Defaults.networkId
         (C.PaymentCredentialByKey $ C.verificationKeyHash $ verificationKey oPaymentKey)

--- a/src/devnet/lib/Convex/Devnet/NodeQueries.hs
+++ b/src/devnet/lib/Convex/Devnet/NodeQueries.hs
@@ -170,19 +170,6 @@ queryUTxOFilterBabbage networkId socket flt =
 -- | Query UTxO for all given addresses at given point.
 --
 -- Throws at least 'QueryException' if query fails.
--- queryUTxOByTxInBabbage :: NetworkId -> FilePath -> Set TxIn -> IO (UTxO C.BabbageEra)
--- queryUTxOByTxInBabbage networkId socket flt =
---   let query =
---         C.QueryInEra
---           ( C.QueryInShelleyBasedEra
---               C.ShelleyBasedEraBabbage
---               ( C.QueryUTxO flt)
---           )
---    in queryLocalState query networkId socket >>= throwOnEraMismatch
-
--- | Query UTxO for all given addresses at given point.
---
--- Throws at least 'QueryException' if query fails.
 queryUTxOFilterConway :: NetworkId -> FilePath -> QueryUTxOFilter -> IO (UTxO C.ConwayEra)
 queryUTxOFilterConway networkId socket flt =
   let query =

--- a/src/devnet/lib/Convex/Devnet/Wallet.hs
+++ b/src/devnet/lib/Convex/Devnet/Wallet.hs
@@ -87,7 +87,7 @@ runningNodeBlockchain ::
  forall e a. (Show e)
   => Tracer IO WalletLog
   -> RunningNode
-  -> (forall m. (MonadFail m, MonadLog m, MonadBlockchain m) => m a)
+  -> (forall m. (MonadFail m, MonadLog m, MonadBlockchain m, MonadIO m) => m a)
   -> IO a
 runningNodeBlockchain tracer RunningNode{rnNodeSocket, rnNetworkId} h =
   let info = NodeQueries.localNodeConnectInfo rnNetworkId rnNodeSocket

--- a/src/devnet/lib/Convex/Devnet/WalletServer.hs
+++ b/src/devnet/lib/Convex/Devnet/WalletServer.hs
@@ -103,7 +103,8 @@ withWallet tracer stateDirectory rn@RunningNode{rnNodeSocket, rnNodeConfigFile, 
                 , rwsManager
                 , rwsClient
                 }
-        _ <- sendFundsToOperator tracer rn op (C.Quantity 100_000_000) >>= NodeQueries.waitForTxn rnNetworkId rnNodeSocket
+        txi <- sendFundsToOperator tracer rn op (C.Quantity 100_000_000)
+        NodeQueries.waitForTxn rnNetworkId rnNodeSocket txi
         waitUntilAvailable tracer rws
         action rws
 

--- a/src/node-client/lib/Convex/NodeClient/WaitForTxnClient.hs
+++ b/src/node-client/lib/Convex/NodeClient/WaitForTxnClient.hs
@@ -53,18 +53,17 @@ waitForTxnClient tmv cp txId env =
 applyBlock :: TMVar BlockInMode -> TxId -> CatchingUp -> () -> LedgerStateUpdate 'NoLedgerState -> BlockInMode -> IO (Maybe ())
 applyBlock tmv txi _ () _ block = do
   case block of
-    C.BlockInMode C.BabbageEra blck ->
+    C.BlockInMode _era blck ->
       if checkTxIds txi blck
         then do
           liftIO $ atomically $ putTMVar tmv block
           pure Nothing
         else pure (Just ())
-    _ -> pure (Just ())
 
-checkTxIds :: TxId -> C.Block C.BabbageEra -> Bool
+checkTxIds :: TxId -> C.Block era -> Bool
 checkTxIds txi ((C.Block _ txns)) = any (checkTxId txi) txns
 
-checkTxId :: TxId -> C.Tx C.BabbageEra -> Bool
+checkTxId :: TxId -> C.Tx era -> Bool
 checkTxId txi tx = txi == C.getTxId (C.getTxBody tx)
 
 newtype MonadBlockchainWaitingT m a = MonadBlockchainWaitingT{unMonadBlockchainWaitingT :: ReaderT (LocalNodeConnectInfo, Env) m a }

--- a/src/node-client/lib/Convex/NodeClient/WaitForTxnClient.hs
+++ b/src/node-client/lib/Convex/NodeClient/WaitForTxnClient.hs
@@ -38,7 +38,7 @@ transaction.
 -}
 runWaitForTxn :: LocalNodeConnectInfo -> Env -> TxId -> IO (TMVar BlockInMode)
 runWaitForTxn connectInfo env txi = do
-  tip' <- NodeQueries.queryTip connectInfo
+  tip' <- NodeQueries.tryQueryTip connectInfo
   tmv <- atomically newEmptyTMVar
   _ <- forkIO $ C.connectToLocalNode connectInfo (protocols $ waitForTxnClient tmv tip' txi env)
   pure tmv

--- a/src/wallet/lib/Convex/Wallet.hs
+++ b/src/wallet/lib/Convex/Wallet.hs
@@ -128,7 +128,7 @@ parse = fmap Wallet . C.deserialiseFromBech32 (C.AsSigningKey C.AsPaymentKey)
 {-| Select Ada-only inputs that cover the given amount of lovelace
 -}
 selectAdaInputsCovering :: UtxoSet ctx a -> C.Quantity -> Maybe (C.Quantity, [C.TxIn])
-selectAdaInputsCovering utxoSet target = selectAnyInputsCovering (onlyAda utxoSet) target
+selectAdaInputsCovering utxoSet = selectAnyInputsCovering (onlyAda utxoSet)
 
 {-| Select Ada-only inputs that cover the given amount of lovelace
 -}
@@ -159,6 +159,4 @@ selectMixedInputsCovering UtxoSet{_utxos} xs =
   in
     find coversTarget
       $ scanl append (mempty, mempty)
-      $ mapMaybe relevantValue
-      $ fmap (second fst)
-      $ Map.toAscList _utxos
+      $ mapMaybe (relevantValue . second fst) (Map.toAscList _utxos)

--- a/src/wallet/lib/Convex/Wallet/NodeClient/BalanceClient.hs
+++ b/src/wallet/lib/Convex/Wallet/NodeClient/BalanceClient.hs
@@ -14,7 +14,7 @@ import           Cardano.Api                (BlockInMode, Env)
 import qualified Cardano.Api                as C
 import           Control.Concurrent.STM     (TVar, atomically, newTVarIO,
                                              writeTVar)
-import           Control.Monad              (when)
+import           Control.Monad              (unless, when)
 import           Control.Monad.IO.Class     (MonadIO (..))
 import           Control.Monad.Trans.Maybe  (runMaybeT)
 import           Convex.MonadLog            (MonadLogKatipT (..), logInfo,
@@ -65,14 +65,14 @@ applyBlock logEnv ns BalanceClientEnv{bceFile, bceState} wallet c (oldC, state) 
       C.BlockInMode _ (C.getBlockHeader -> header) = block
       newState = WalletState.walletState newUTxOs header
 
-  when (not $ Utxos.null change) $ do
+  unless (Utxos.null change) $ do
     logInfo $ PrettyUtxoChange change
     logInfo $ PrettyBalance newUTxOs
 
   when (catchingUp oldC &&  not (catchingUp c)) $
     logInfoS "Caught up with node"
 
-  when (not $ catchingUp c) $ do
+  unless (catchingUp c) $ do
     liftIO (WalletState.writeToFile bceFile newState)
 
   liftIO $ writeState bceState newState


### PR DESCRIPTION
This change allows node clients that use sc-tools to keep working after the conway hard-fork

* Change the node queries to work in both babbage and conway eras. A new module `Convex.Eras` is added with some utilities for working with era-agnostic values and for converting some conway-era types to babbage-era types
* Leave the tx building code unchanged. This means that for now it's not possible to build conway-era transactions. But babbage-era transactions still work. When the HF has happened on mainnet we will switch the tx building code to support babbage-era only, so that we don't have to deal with multiple eras here.
* Add integration tests for conway era