### PR TITLE
Add simple script mint/spend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,1 @@
+/nix/store/3byva98dv9ps7yx41q8yc0a44dysrqi4-pre-commit-config.json

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -55,6 +55,7 @@ module Convex.BuildTx(
   spendPlutusV2RefWithoutInRef,
   spendPlutusV2RefWithoutInRefInlineDatum,
   spendPlutusV2InlineDatum,
+  spendSimpleScript,
 
   -- ** Adding outputs
   payToAddress,
@@ -81,6 +82,7 @@ module Convex.BuildTx(
   mintPlutusV1,
   mintPlutusV2,
   mintPlutusV2Ref,
+  mintSimpleScriptAssets,
 
   -- ** Constructing script witness
   buildV1ScriptWitness,
@@ -124,6 +126,7 @@ import           Convex.Class                  (MonadBlockchain (..),
 import           Convex.MonadLog               (MonadLog (..), MonadLogIgnoreT,
                                                 MonadLogKatipT)
 import           Convex.Scripts                (toHashableScriptData)
+import           Data.Foldable                 (traverse_)
 import           Data.Functor.Identity         (Identity (..))
 import           Data.List                     (nub)
 import qualified Data.Map                      as Map
@@ -474,6 +477,17 @@ mintPlutusV2Ref refTxIn sh red assetName quantity =
   in  setScriptsValid
       >> addBtx (over (L.txMintValue . L._TxMintValue) (over _1 (<> v) . over _2 (Map.insert policyId wit)))
       >> addReference refTxIn
+
+mintSimpleScriptAssets :: MonadBuildTx m => C.SimpleScript -> [(C.AssetName, C.Quantity)] -> m ()
+mintSimpleScriptAssets sscript assets =
+  let wit = C.SimpleScriptWitness C.SimpleScriptInBabbage (C.SScript sscript)
+      policyId = C.scriptPolicyId . C.SimpleScript $ sscript
+  in traverse_ (\(an,q) -> addMintWithTxBody policyId an q (const wit)) assets
+
+spendSimpleScript :: MonadBuildTx m => C.TxIn -> C.SimpleScript -> m ()
+spendSimpleScript txIn sscript =
+  let wit = C.SimpleScriptWitness C.SimpleScriptInBabbage (C.SScript sscript)
+  in addBtx (over L.txIns ((txIn, C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending wit) :))
 
 addCollateral :: MonadBuildTx m => C.TxIn -> m ()
 addCollateral i = addBtx $ over (L.txInsCollateral . L._TxInsCollateralIso) ((:) i)

--- a/src/base/lib/Convex/Class.hs
+++ b/src/base/lib/Convex/Class.hs
@@ -88,7 +88,8 @@ import           Cardano.Ledger.Shelley.API                        (ApplyTxError
                                                                     MempoolEnv,
                                                                     MempoolState,
                                                                     UTxO (..),
-                                                                    Validated, extractTx)
+                                                                    Validated,
+                                                                    extractTx)
 import           Cardano.Ledger.Shelley.LedgerState                (certDStateL,
                                                                     dsUnifiedL,
                                                                     lsCertStateL,
@@ -98,7 +99,8 @@ import           Cardano.Ledger.UMap                               (RDPair (..),
                                                                     compactCoinOrError)
 import           Cardano.Slotting.Time                             (SlotLength,
                                                                     SystemStart)
-import           Control.Lens                                      (_1, set, view, (^.), to)
+import           Control.Lens                                      (_1, set, to,
+                                                                    view, (^.))
 import           Control.Lens.TH                                   (makeLensesFor,
                                                                     makePrisms)
 import           Control.Monad.Except                              (MonadError,
@@ -355,8 +357,8 @@ setUtxo :: MonadMockchain m => UTxO ERA -> m ()
 setUtxo u = modifyUtxo (const (u, ()))
 
 {-| Return all Tx's from the ledger state -}
-getTxs :: MonadMockchain m => m [Core.Tx ERA]
-getTxs = getMockChainState <&> view (transactions . traverse . _1 . to ((: []) . extractTx))
+getTxs :: MonadMockchain m => m [C.Tx C.BabbageEra] --  [Core.Tx ERA]
+getTxs = getMockChainState <&> view (transactions . traverse . _1 . to ((: []) . C.ShelleyTx C.ShelleyBasedEraBabbage . extractTx))
 
 {-| Return all Tx's from the ledger state -}
 


### PR DESCRIPTION
* Adds helpers `mintSimpleScriptAssets` & `spendSimpleScript` to build tx module.
* Fix `getTxs` returning `LedgerTx` type.