### PR TITLE
Add cardano-api tx lenses

### DIFF
--- a/src/base/lib/Convex/Class.hs
+++ b/src/base/lib/Convex/Class.hs
@@ -232,7 +232,6 @@ singleUTxO txi =  utxoByTxIn (Set.singleton txi) >>= \case
   C.UTxO (Map.toList -> [(_, o)]) -> pure (Just o)
   _ -> pure Nothing
 
-
 {- Note [sendTx Failure]
 
 It would be nice to return a more accurate error type than 'SendTxFailed',

--- a/src/optics/convex-optics.cabal
+++ b/src/optics/convex-optics.cabal
@@ -29,6 +29,7 @@ library
     import: lang
     exposed-modules:
       Convex.Scripts
+      Convex.CardanoApi
       Convex.CardanoApi.Lenses
       Convex.PlutusLedgerApi.Optics
     hs-source-dirs: lib
@@ -38,6 +39,7 @@ library
       cardano-ledger-core,
       cardano-ledger-shelley,
       cardano-ledger-mary,
+      cardano-ledger-alonzo,
       containers,
       lens,
       ouroboros-consensus-cardano,

--- a/src/optics/lib/Convex/CardanoApi.hs
+++ b/src/optics/lib/Convex/CardanoApi.hs
@@ -1,0 +1,21 @@
+module Convex.CardanoApi
+  ( txBodyScriptDataDatums
+  , txBodyScriptDataRedeemers
+  ) where
+
+import qualified Cardano.Api.Shelley          as C
+import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
+import           Data.Bifunctor               (bimap)
+import           Data.Map                     (Map)
+import qualified Data.Map                     as Map
+
+txBodyScriptDataDatums :: C.TxBodyScriptData era -> Map (C.Hash C.ScriptData) C.HashableScriptData
+txBodyScriptDataDatums C.TxBodyNoScriptData = mempty
+txBodyScriptDataDatums (C.TxBodyScriptData _ (Ledger.TxDats' dats) _) =
+  Map.fromList $ fmap (bimap C.ScriptDataHash C.fromAlonzoData) $ Map.toList dats
+
+txBodyScriptDataRedeemers :: C.TxBodyScriptData era -> Map C.ScriptWitnessIndex C.HashableScriptData
+txBodyScriptDataRedeemers C.TxBodyNoScriptData = mempty
+txBodyScriptDataRedeemers (C.TxBodyScriptData aeo _ (Ledger.Redeemers reds)) =
+  Map.fromList $ fmap (\(purpose, (red, _)) -> (C.toScriptIndex aeo purpose, C.fromAlonzoData red)) $ Map.toList reds
+

--- a/src/optics/lib/Convex/CardanoApi/Lenses.hs
+++ b/src/optics/lib/Convex/CardanoApi/Lenses.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 {-| Lenses for @cardano-api@ types
 -}
 module Convex.CardanoApi.Lenses(
@@ -13,6 +14,13 @@ module Convex.CardanoApi.Lenses(
   IsMaryEraOnwards (..),
   IsAlonzoEraOnwards (..),
   IsBabbageEraOnwards (..),
+  -- * Tx lenses
+  txBody,
+  -- * Tx body lenses
+  txBodyContent,
+  txBodyScriptData,
+  datums,
+  redeemers,
   -- * Tx body content lenses
   emptyTx,
   emptyTxOut,
@@ -132,6 +140,8 @@ import           Cardano.Ledger.Shelley.LedgerState (LedgerState (..),
 import           Control.Lens                       (Getter, Iso', Lens',
                                                      Prism', iso, lens, prism')
 import qualified Control.Lens                       as L
+import           Convex.CardanoApi                  (txBodyScriptDataDatums,
+                                                     txBodyScriptDataRedeemers)
 import qualified Convex.Scripts                     as Scripts
 import           Data.Map.Strict                    (Map)
 import qualified Data.Map.Strict                    as Map
@@ -207,6 +217,24 @@ instance IsBabbageEraOnwards C.BabbageEra where
 
 instance IsBabbageEraOnwards C.ConwayEra where
    babbageEraOnwards = C.BabbageEraOnwardsConway
+
+txBody :: Getter (C.Tx era) (C.TxBody era)
+txBody = L.to get_ where
+  get_ (C.Tx txb _) = txb
+
+txBodyContent :: Getter (C.TxBody era) (C.TxBodyContent C.ViewTx era)
+txBodyContent = L.to get_ where
+  get_ (C.TxBody txbc) = txbc
+
+txBodyScriptData :: Getter (C.TxBody era) (C.TxBodyScriptData era)
+txBodyScriptData = L.to get_ where
+  get_ (C.ShelleyTxBody _ _ _ scriptData _ _) = scriptData
+
+datums :: Getter (C.TxBodyScriptData era) (Map (C.Hash C.ScriptData) C.HashableScriptData)
+datums = L.to txBodyScriptDataDatums
+
+redeemers :: Getter (C.TxBodyScriptData era) (Map C.ScriptWitnessIndex C.HashableScriptData)
+redeemers = L.to txBodyScriptDataRedeemers
 
 {-| 'TxBodyContent' with all fields set to empty, none, default values
 TODO Remove and replace with C.defaultTxBodyContent


### PR DESCRIPTION
Add cardano-api tx lenses for extracting the TxBody from a Tx, as well as extracting the datums and redeemers from Tx.