### PR TITLE
Era constraints, cardano-api-9.3.0.0

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -40,7 +40,8 @@ jobs:
       - name: Build dependencies for integration test
         run: |
           cabal update
-          cabal install -j cardano-node cardano-cli convex-wallet --overwrite-policy=always
+          cabal install -j cardano-node cardano-cli --overwrite-policy=always
+          cabal install -j convex-wallet --overwrite-policy=always
           echo "/home/runner/.cabal/bin" >> $GITHUB_PATH
 
       - name: build & test

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `main` branch uses the following versions of its major dependencies:
 
 |Name|Version|
 |--|--|
-|`cardano-node`|[9.1.0](https://github.com/IntersectMBO/cardano-node/releases/tag/9.1.0)|
+|`cardano-node`|[9.1.1](https://github.com/IntersectMBO/cardano-node/releases/tag/9.1.1)|
 |`cardano-api`|[9.3.0.0](https://chap.intersectmbo.org/package/cardano-api-9.3.0.0/)|
 |`ghc`|9.6.6|
 |`cabal`|3.10.3.0|

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `main` branch uses the following versions of its major dependencies:
 |Name|Version|
 |--|--|
 |`cardano-node`|[9.1.0](https://github.com/IntersectMBO/cardano-node/releases/tag/9.1.0)|
-|`cardano-api`|[9.1.0.0](https://chap.intersectmbo.org/package/cardano-api-9.1.0.0/)|
+|`cardano-api`|[9.3.0.0](https://chap.intersectmbo.org/package/cardano-api-9.3.0.0/)|
 |`ghc`|9.6.6|
 |`cabal`|3.10.3.0|
 

--- a/cabal.project
+++ b/cabal.project
@@ -18,12 +18,7 @@ index-state:
   , hackage.haskell.org 2024-10-01T11:46:38Z
   , cardano-haskell-packages 2024-09-17T19:03:21Z
 
--- Always build tests and benchmarks.
-tests: true
-benchmarks: true
-
--- Always build documentation
-documentation: true
+multi-repl: true
 
 packages:
   src/base

--- a/cabal.project
+++ b/cabal.project
@@ -15,8 +15,8 @@ repository cardano-haskell-packages
 
 with-compiler: ghc-9.6.6
 index-state:
-  , hackage.haskell.org 2024-09-17T00:00:00Z
-  , cardano-haskell-packages 2024-09-17T00:00:00Z
+  , hackage.haskell.org 2024-10-01T11:46:38Z
+  , cardano-haskell-packages 2024-09-17T19:03:21Z
 
 -- Always build tests and benchmarks.
 tests: true

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1721831314,
-        "narHash": "sha256-I1j5HPSbbh3l1D0C9oP/59YB4e+64K9NDRl7ueD1c/Y=",
+        "lastModified": 1728036389,
+        "narHash": "sha256-Hz8vipWq6T/NjvkxBMUFfMcfEDz4M8TEnys/rVNyzR4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "8815ee7598bc39a02db8896b788f69accf892790",
+        "rev": "e357094c61a6215ca7d83c4077fd62c43d07ccff",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1721867175,
-        "narHash": "sha256-1yD5lI+LtM2bMjjREucK3Y1WcKXQw0N6b8xSJty7A5I=",
+        "lastModified": 1728260941,
+        "narHash": "sha256-Y9Rj7OH/iwkx26l0X0+06IBHCb9StYWIY1i+nSs2vrg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "62bf49579c1b900d0a930d96040d65d49c7131a6",
+        "rev": "afc093680796bf75671750f20b6eaa3c71cc3bfb",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1721868640,
-        "narHash": "sha256-iOugjcRcgSNAfu+D9YQSV0yu7086k8MQuhd5Sx9/XMU=",
+        "lastModified": 1728262266,
+        "narHash": "sha256-qKsVkP+tThzC4cF+V0XKbgP6qchv8WQQRmXlaB+uwuI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "1e71885e0094c98df536a25155cafc577a4b47fd",
+        "rev": "741af0b3ea023287c0449ec72c00792a7df4175e",
         "type": "github"
       },
       "original": {
@@ -396,16 +396,16 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1718469202,
-        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
+        "lastModified": 1720003792,
+        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
+        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.9.0.0",
+        "ref": "2.9.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -654,11 +654,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1720122915,
-        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "lastModified": 1726447378,
+        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
         "type": "github"
       },
       "original": {
@@ -670,14 +670,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -698,11 +698,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1720181791,
-        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
+        "lastModified": 1726583932,
+        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
+        "rev": "658e7223191d2598641d50ee4e898126768fe847",
         "type": "github"
       },
       "original": {
@@ -795,11 +795,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1721866306,
-        "narHash": "sha256-j5Z56zaK1GdnsJuFhuR6WnMw3tBZ0wM8+TdkP/DL6ps=",
+        "lastModified": 1728259897,
+        "narHash": "sha256-mwopeDSr1FFlfzfAXUfRitqEYVes0Jt5GeJBijk7lh0=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "90c884a7dfb82cee528bfc044733bba188dea43a",
+        "rev": "681e49db5efad4a607d0f6ac5568458276af3336",
         "type": "github"
       },
       "original": {

--- a/src/base/convex-base.cabal
+++ b/src/base/convex-base.cabal
@@ -58,7 +58,7 @@ library
     build-depends:
       convex-optics,
 
-      cardano-api == 9.1.0.0,
+      cardano-api == 9.3.0.0,
       cardano-ledger-core,
       cardano-crypto-wrapper,
 

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
 {-# LANGUAGE ViewPatterns           #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-deprecations #-} -- see https://github.com/j-mueller/sc-tools/issues/213
 {-| Building transactions
 -}
 module Convex.BuildTx(

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -1,12 +1,18 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE NamedFieldPuns       #-}
-{-# LANGUAGE NumericUnderscores   #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns         #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE DefaultSignatures      #-}
+{-# LANGUAGE DerivingStrategies     #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE NamedFieldPuns         #-}
+{-# LANGUAGE NumericUnderscores     #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeOperators          #-}
+{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE ViewPatterns           #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-| Building transactions
 -}
 module Convex.BuildTx(
@@ -50,13 +56,12 @@ module Convex.BuildTx(
 
   -- ** Variations of @addInput@
   spendPublicKeyOutput,
-  spendPlutusV1,
-  spendPlutusV2,
-  spendPlutusV2Ref,
-  spendPlutusV2RefWithInlineDatum,
-  spendPlutusV2RefWithoutInRef,
-  spendPlutusV2RefWithoutInRefInlineDatum,
-  spendPlutusV2InlineDatum,
+  spendPlutus,
+  spendPlutusRef,
+  spendPlutusRefWithInlineDatum,
+  spendPlutusRefWithoutInRef,
+  spendPlutusRefWithoutInRefInlineDatum,
+  spendPlutusInlineDatum,
   spendSimpleScript,
 
   -- ** Adding outputs
@@ -64,12 +69,12 @@ module Convex.BuildTx(
   payToAddressTxOut,
   payToPublicKey,
   payToScriptHash,
-  payToPlutusV1,
-  payToPlutusV2,
-  payToPlutusV2InlineDatum,
-  payToPlutusV2Inline,
-  payToPlutusV2InlineWithInlineDatum,
-  payToPlutusV2InlineWithDatum,
+  payToScriptDatumHash,
+  payToScriptInlineDatum,
+  createRefScriptBase,
+  createRefScriptNoDatum,
+  createRefScriptDatumHash,
+  createRefScriptInlineDatum,
 
   -- ** Staking
   addWithdrawal,
@@ -82,15 +87,13 @@ module Convex.BuildTx(
   addStakeWitness,
 
   -- ** Minting and burning tokens
-  mintPlutusV1,
-  mintPlutusV2,
-  mintPlutusV2Ref,
+  mintPlutus,
+  mintPlutusRef,
   mintSimpleScriptAssets,
 
   -- ** Constructing script witness
-  buildV1ScriptWitness,
-  buildV2ScriptWitness,
-  buildV2RefScriptWitness,
+  buildScriptWitness,
+  buildRefScriptWitness,
 
   -- ** Utilities
   assetValue,
@@ -98,66 +101,83 @@ module Convex.BuildTx(
   -- * Minimum Ada deposit
   minAdaDeposit,
   setMinAdaDeposit,
-  setMinAdaDepositAll
+  setMinAdaDepositAll,
+
+  -- * Others
+  simpleScriptInShelleyEra,
+  mkTxOutValue
   ) where
 
-import           Cardano.Api.Shelley           (Hash, HashableScriptData,
-                                                NetworkId, PaymentKey,
-                                                PlutusScript, PlutusScriptV1,
-                                                PlutusScriptV2, ScriptHash,
-                                                WitCtxTxIn)
-import qualified Cardano.Api.Shelley           as C
-import qualified Cardano.Ledger.Shelley.TxCert as TxCert
-import           Control.Lens                  (_1, _2, at, mapped, over, set,
-                                                view, (&))
-import qualified Control.Lens                  as L
-import           Control.Monad.Except          (MonadError (..))
-import           Control.Monad.Primitive       (PrimMonad (..))
-import           Control.Monad.Reader.Class    (MonadReader (..))
-import qualified Control.Monad.State           as LazyState
-import           Control.Monad.State.Class     (MonadState (..))
-import qualified Control.Monad.State.Strict    as StrictState
-import           Control.Monad.Trans.Class     (MonadTrans (..))
-import           Control.Monad.Trans.Except    (ExceptT)
-import           Control.Monad.Writer          (WriterT, execWriterT,
-                                                runWriterT)
-import           Control.Monad.Writer.Class    (MonadWriter (..))
-import qualified Convex.CardanoApi.Lenses      as L
-import           Convex.Class                  (MonadBlockchain (..),
-                                                MonadBlockchainCardanoNodeT,
-                                                MonadDatumQuery (queryDatumFromHash),
-                                                MonadMockchain (..))
-import           Convex.MonadLog               (MonadLog (..), MonadLogIgnoreT,
-                                                MonadLogKatipT)
-import           Convex.Scripts                (toHashableScriptData)
-import           Data.Foldable                 (traverse_)
-import           Data.Functor.Identity         (Identity (..))
-import           Data.List                     (nub)
-import qualified Data.Map                      as Map
-import           Data.Maybe                    (fromJust, fromMaybe)
-import qualified Data.Set                      as Set
-import qualified PlutusLedgerApi.V1            as Plutus
+import           Cardano.Api.Shelley            (Hash, HashableScriptData,
+                                                 NetworkId, PaymentKey,
+                                                 PlutusScript, PlutusScriptV2,
+                                                 ScriptHash, WitCtxTxIn)
+import qualified Cardano.Api.Shelley            as C
+import qualified Cardano.Ledger.Shelley.TxCert  as TxCert
+import           Control.Lens                   (_1, _2, at, mapped, over, set,
+                                                 view, (&))
+import qualified Control.Lens                   as L
+import           Control.Monad.Except           (MonadError (..))
+import           Control.Monad.Reader.Class     (MonadReader (..))
+import qualified Control.Monad.State            as LazyState
+import           Control.Monad.State.Class      (MonadState (..))
+import qualified Control.Monad.State.Strict     as StrictState
+import           Control.Monad.Trans.Class      (MonadTrans (..))
+import           Control.Monad.Trans.Except     (ExceptT)
+import           Control.Monad.Trans.Writer.CPS (WriterT, execWriterT,
+                                                 runWriterT)
+import           Control.Monad.Writer.Class     (MonadWriter (..))
+import qualified Convex.CardanoApi.Lenses       as L
+import           Convex.Class                   (MonadBlockchain (..),
+                                                 MonadBlockchainCardanoNodeT,
+                                                 MonadDatumQuery (queryDatumFromHash),
+                                                 MonadMockchain (..))
+import           Convex.MonadLog                (MonadLog (..), MonadLogIgnoreT,
+                                                 MonadLogKatipT)
+import           Convex.Scripts                 (toHashableScriptData)
+import           Convex.Utils                   (inAlonzo, inBabbage, inMary)
+import           Data.Foldable                  (traverse_)
+import           Data.Functor.Identity          (Identity (..))
+import           Data.List                      (nub)
+import qualified Data.Map                       as Map
+import           Data.Maybe                     (fromJust)
+import qualified Data.Set                       as Set
+import qualified PlutusLedgerApi.V1             as Plutus
 
-type TxBody = C.TxBodyContent C.BuildTx C.ConwayEra
+type TxBody era = C.TxBodyContent C.BuildTx era
+
+simpleScriptInShelleyEra :: forall era. C.IsShelleyBasedEra era => C.ScriptLanguageInEra C.SimpleScript' era
+simpleScriptInShelleyEra = case C.shelleyBasedEra @era of
+  C.ShelleyBasedEraShelley -> C.SimpleScriptInShelley
+  C.ShelleyBasedEraAllegra -> C.SimpleScriptInAllegra
+  C.ShelleyBasedEraMary    -> C.SimpleScriptInMary
+  C.ShelleyBasedEraAlonzo  -> C.SimpleScriptInAlonzo
+  C.ShelleyBasedEraBabbage -> C.SimpleScriptInBabbage
+  C.ShelleyBasedEraConway  -> C.SimpleScriptInConway
+
+mkTxOutValue :: forall era. C.IsMaryBasedEra era => C.Value -> C.TxOutValue era
+mkTxOutValue val =
+  C.maryEraOnwardsConstraints @era C.maryBasedEra $ C.TxOutValueShelleyBased C.shelleyBasedEra $ C.toMaryValue val
+
 
 {-| Look up the index of the @TxIn@ in the list of spending inputs
 -}
-lookupIndexSpending :: C.TxIn -> TxBody -> Maybe Int
+lookupIndexSpending :: C.TxIn -> TxBody era -> Maybe Int
 lookupIndexSpending txi = Map.lookupIndex txi . Map.fromList . (fmap (view L._BuildTxWith) <$>) . view L.txIns
 
 {-| Look up the index of the @TxIn@ in the list of spending inputs. Throws an error if the @TxIn@ is not present.
 -}
-findIndexSpending :: C.TxIn -> TxBody -> Int
+findIndexSpending :: C.TxIn -> TxBody era -> Int
 findIndexSpending txi = fromJust . lookupIndexSpending txi
 
 {-| Look up the index of the @TxIn@ in the list of reference inputs
 -}
-lookupIndexReference :: C.TxIn -> TxBody -> Maybe Int
+lookupIndexReference :: C.IsBabbageBasedEra era => C.TxIn -> TxBody era -> Maybe Int
 lookupIndexReference txi = Set.lookupIndex txi . Set.fromList . view (L.txInsReference . L._TxInsReferenceIso)
 
 {-| Look up the index of the @TxIn@ in the list of reference inputs. Throws an error if the @TxIn@ is not present.
 -}
-findIndexReference :: C.TxIn -> TxBody -> Int
+findIndexReference :: C.IsBabbageBasedEra era => C.TxIn -> TxBody era -> Int
 findIndexReference txi = fromJust . lookupIndexReference txi
 
 {-| Look up the index of the @PolicyId@ in the transaction mint.
@@ -166,22 +186,22 @@ which is @Map CurrencySymbol (Map TokenName Quantity).
 Here, we want to get the index into the on-chain map, but instead index into the cardano-api @Map CurrencySymbol Witness@.
 These two indexes should be the same by construction, but it is possible to violate this invariant when building a tx.
 -}
-lookupIndexMinted :: C.PolicyId -> TxBody -> Maybe Int
+lookupIndexMinted :: C.IsMaryBasedEra era => C.PolicyId -> TxBody era -> Maybe Int
 lookupIndexMinted policy = Map.lookupIndex policy . view (L.txMintValue . L._TxMintValue .  _2)
 
 {-| Look up the index of the @PolicyId@ in the transaction mint. Throws an error if the @PolicyId@ is not present.
 -}
-findIndexMinted :: C.PolicyId -> TxBody -> Int
+findIndexMinted :: C.IsMaryBasedEra era => C.PolicyId -> TxBody era -> Int
 findIndexMinted policy = fromJust . lookupIndexMinted policy
 
 {-| Look up the index of the @StakeAddress@ in the list of withdrawals.
 -}
-lookupIndexWithdrawal :: C.StakeAddress -> TxBody -> Maybe Int
+lookupIndexWithdrawal :: C.IsShelleyBasedEra era => C.StakeAddress -> TxBody era -> Maybe Int
 lookupIndexWithdrawal stakeAddress = Set.lookupIndex stakeAddress . Set.fromList . fmap (view _1) . view (L.txWithdrawals . L._TxWithdrawals)
 
 {-| Look up the index of the @StakeAddress@ in the list of withdrawals. Throws an error if the @StakeAddress@ is not present.
 -}
-findIndexWithdrawal :: C.StakeAddress -> TxBody -> Int
+findIndexWithdrawal :: C.IsShelleyBasedEra era => C.StakeAddress -> TxBody era -> Int
 findIndexWithdrawal stakeAddress = fromJust . lookupIndexWithdrawal stakeAddress
 
 
@@ -193,138 +213,100 @@ Note that the result of @unTxBuilder txBody@ must not completely force the @txBo
 or refer to itself circularly. For example, using this to construct a redeemer that contains the whole
 @TransactionInputs@ map is going to loop forever.
 -}
-newtype TxBuilder = TxBuilder{ unTxBuilder :: TxBody -> TxBody -> TxBody }
+newtype TxBuilder era = TxBuilder{ unTxBuilder :: TxBody era -> TxBody era -> TxBody era }
 
 {-| Construct the final @TxBodyContent@
 -}
-buildTx :: TxBuilder -> TxBody
+buildTx :: C.IsShelleyBasedEra era => TxBuilder era -> TxBody era
 buildTx txb = buildTxWith txb L.emptyTx
 
 -- | The 'TxBuilder' that modifies the tx body without looking at the final result
-liftTxBodyEndo :: (TxBody -> TxBody) -> TxBuilder
+liftTxBodyEndo :: (TxBody era -> TxBody era) -> TxBuilder era
 liftTxBodyEndo f = TxBuilder (const f)
 
 {-| Construct the final @TxBodyContent@ from the provided @TxBodyContent@
 -}
-buildTxWith :: TxBuilder -> TxBody -> TxBody
+buildTxWith :: TxBuilder era -> TxBody era -> TxBody era
 buildTxWith TxBuilder{unTxBuilder} initial =
   let result = unTxBuilder result initial
   in result
 
-instance Semigroup TxBuilder where
+instance Semigroup (TxBuilder era) where
     -- note that the order here is reversed, compared to @Data.Monoid.Endo@.
     -- This is so that @addBtx a >> addBtx b@ will result in a transaction
     -- where @a@ has been applied before @b@.
   (TxBuilder l) <> (TxBuilder r) = TxBuilder $ \k -> r k . l k
 
-instance Monoid TxBuilder where
+instance Monoid (TxBuilder era) where
   mempty = TxBuilder $ const id
 
 {-| An effect that collects @TxBuilder@ values for building
 cardano transactions
 -}
-class Monad m => MonadBuildTx m where
+class Monad m => MonadBuildTx era m | m -> era where
   -- | Add a @TxBuilder@
-  addTxBuilder :: TxBuilder -> m ()
+  addTxBuilder :: TxBuilder era -> m ()
 
-instance MonadBuildTx m => MonadBuildTx (ExceptT e m) where
+  default addTxBuilder :: (MonadTrans t, m ~ t n, MonadBuildTx era n) => TxBuilder era -> m ()
   addTxBuilder = lift . addTxBuilder
 
-instance MonadBuildTx m => MonadBuildTx (StrictState.StateT e m) where
-  addTxBuilder = lift . addTxBuilder
+instance MonadBuildTx era m => MonadBuildTx era (ExceptT e m)
+instance MonadBuildTx era m => MonadBuildTx era (StrictState.StateT e m)
+instance MonadBuildTx era m => MonadBuildTx era (LazyState.StateT e m)
+instance (Monoid w, MonadBuildTx era m) => MonadBuildTx era (WriterT w m)
+instance MonadBuildTx era m => MonadBuildTx era (MonadBlockchainCardanoNodeT era m)
+instance MonadBuildTx era m => MonadBuildTx era (MonadLogIgnoreT m)
+instance MonadBuildTx era m => MonadBuildTx era (MonadLogKatipT m)
 
-instance MonadBuildTx m => MonadBuildTx (LazyState.StateT e m) where
-  addTxBuilder = lift . addTxBuilder
-
-instance (Monoid w, MonadBuildTx m) => MonadBuildTx (WriterT w m) where
-  addTxBuilder = lift . addTxBuilder
-
-instance MonadBuildTx m => MonadBuildTx (MonadBlockchainCardanoNodeT e m) where
-  addTxBuilder = lift . addTxBuilder
-
-instance MonadBuildTx m => MonadBuildTx (MonadLogIgnoreT m) where
-  addTxBuilder = lift . addTxBuilder
-
-instance MonadBuildTx m => MonadBuildTx (MonadLogKatipT m) where
-  addTxBuilder = lift . addTxBuilder
-
-addBtx :: MonadBuildTx m => (TxBody -> TxBody) -> m ()
+addBtx :: MonadBuildTx era m => (TxBody era -> TxBody era) -> m ()
 addBtx = addTxBuilder . TxBuilder . const
 
 {-| Monad transformer for the @MonadBuildTx@ effect
 -}
-newtype BuildTxT m a = BuildTxT{unBuildTxT :: WriterT TxBuilder m a }
-  deriving newtype (Functor, Applicative, Monad)
+newtype BuildTxT era m a = BuildTxT{unBuildTxT :: WriterT (TxBuilder era) m a }
+  deriving newtype (Functor, Applicative, Monad, MonadReader r, MonadState s, MonadError e)
 
-instance PrimMonad m => PrimMonad (BuildTxT m) where
-  type PrimState (BuildTxT m) = PrimState m
-  {-# INLINEABLE primitive #-}
-  primitive f = lift (primitive f)
-
-instance MonadTrans BuildTxT where
+instance MonadTrans (BuildTxT era) where
   lift = BuildTxT . lift
 
-instance Monad m => MonadBuildTx (BuildTxT m) where
+instance Monad m => MonadBuildTx era (BuildTxT era m) where
   addTxBuilder = BuildTxT . tell
 
-instance MonadError e m => MonadError e (BuildTxT m) where
-  throwError = lift . throwError
-  catchError m action = BuildTxT (unBuildTxT $ catchError m action)
+instance MonadBlockchain era m => MonadBlockchain era (BuildTxT era m)
+instance MonadMockchain era m => MonadMockchain era (BuildTxT era m)
 
-instance MonadReader e m => MonadReader e (BuildTxT m) where
-  ask = lift ask
-  local f = BuildTxT . local f . unBuildTxT
-
-instance MonadBlockchain m => MonadBlockchain (BuildTxT m) where
-  sendTx = lift . sendTx
-  utxoByTxIn = lift . utxoByTxIn
-  queryProtocolParameters = lift queryProtocolParameters
-  queryStakeAddresses creds = lift . queryStakeAddresses creds
-  queryStakePools = lift queryStakePools
-  querySystemStart = lift querySystemStart
-  queryEraHistory = lift queryEraHistory
-  querySlotNo = lift querySlotNo
-  queryNetworkId = lift queryNetworkId
-
-instance MonadMockchain m => MonadMockchain (BuildTxT m) where
-  modifyMockChainState = lift . modifyMockChainState
-  askNodeParams = lift askNodeParams
-
-instance MonadDatumQuery m => MonadDatumQuery (BuildTxT m) where
+instance MonadDatumQuery m => MonadDatumQuery (BuildTxT era m) where
   queryDatumFromHash = lift . queryDatumFromHash
 
-instance MonadState s m => MonadState s (BuildTxT m) where
-  state = lift . state
-
-instance MonadLog m => MonadLog (BuildTxT m) where
+instance MonadLog m => MonadLog (BuildTxT era m) where
   logInfo' = lift . logInfo'
   logWarn' = lift . logWarn'
   logDebug' = lift . logDebug'
 
 {-| Run the @BuildTxT@ monad transformer
 -}
-runBuildTxT :: BuildTxT m a -> m (a, TxBuilder)
+runBuildTxT :: BuildTxT era m a -> m (a, TxBuilder era)
 runBuildTxT = runWriterT . unBuildTxT
 
 {-| Run the @BuildTxT@ monad transformer, returning the @TxBuild@ part only
 -}
-execBuildTxT :: Monad m => BuildTxT m a -> m TxBuilder
+execBuildTxT :: Monad m => BuildTxT era m a -> m (TxBuilder era)
 execBuildTxT = execWriterT . unBuildTxT
 
 {-| Run the @BuildTxT@ monad transformer, returnin only the result
 -}
-evalBuildTxT :: Monad m => BuildTxT m a -> m a
+evalBuildTxT :: Monad m => BuildTxT era m a -> m a
 evalBuildTxT = fmap fst . runWriterT . unBuildTxT
 
-runBuildTx :: BuildTxT Identity a -> (a, TxBuilder)
+runBuildTx :: BuildTxT era Identity a -> (a, TxBuilder era)
 runBuildTx = runIdentity . runBuildTxT
 
-execBuildTx :: BuildTxT Identity a -> TxBuilder
+execBuildTx :: BuildTxT era Identity a -> TxBuilder era
 execBuildTx = runIdentity . execBuildTxT
 
 {-| Run the @BuildTx@ action and produce a transaction body
 -}
-execBuildTx' :: BuildTxT Identity a -> TxBody
+execBuildTx' :: C.IsShelleyBasedEra era => BuildTxT era Identity a -> TxBody era
 execBuildTx' = buildTx . runIdentity . execBuildTxT
 
 {-| These functions allow to build the witness for an input/asset/withdrawal
@@ -333,58 +315,44 @@ constructing the witness, make sure that the witness does not depend on
 itself. For example: @addInputWithTxBody txi (\body -> find (\in -> in == txi) (txInputs body))@
 is going to loop.
 -}
-addInputWithTxBody :: MonadBuildTx m => C.TxIn -> (TxBody -> C.Witness WitCtxTxIn C.ConwayEra) -> m ()
+addInputWithTxBody :: MonadBuildTx era m => C.TxIn -> (TxBody era -> C.Witness WitCtxTxIn era) -> m ()
 addInputWithTxBody txIn f = addTxBuilder (TxBuilder $ \body -> over L.txIns ((txIn, C.BuildTxWith $ f body) :))
 
-addMintWithTxBody :: MonadBuildTx m => C.PolicyId -> C.AssetName -> C.Quantity -> (TxBody -> C.ScriptWitness C.WitCtxMint C.ConwayEra) -> m ()
+addMintWithTxBody :: (MonadBuildTx era m, C.IsMaryBasedEra era) => C.PolicyId -> C.AssetName -> C.Quantity -> (TxBody era -> C.ScriptWitness C.WitCtxMint era) -> m ()
 addMintWithTxBody policy assetName quantity f =
   let v = assetValue (C.unPolicyId policy) assetName quantity
   in addTxBuilder (TxBuilder $ \body -> over (L.txMintValue . L._TxMintValue) (over _1 (<> v) . over _2 (Map.insert policy (f body))))
 
-addWithdrawalWithTxBody ::  MonadBuildTx m => C.StakeAddress -> C.Quantity -> (TxBody -> C.Witness C.WitCtxStake C.ConwayEra) -> m ()
+addWithdrawalWithTxBody :: (MonadBuildTx era m, C.IsShelleyBasedEra era) => C.StakeAddress -> C.Quantity -> (TxBody era -> C.Witness C.WitCtxStake era) -> m ()
 addWithdrawalWithTxBody address amount f =
   addTxBuilder (TxBuilder $ \body -> over (L.txWithdrawals . L._TxWithdrawals) ((address, C.quantityToLovelace amount, C.BuildTxWith $ f body) :))
 
 {- | Like @addStakeWitness@ but uses a function that takes a @TxBody@ to build the witness.
 -}
-addStakeWitnessWithTxBody :: MonadBuildTx m => C.StakeCredential -> (TxBody -> C.Witness C.WitCtxStake C.ConwayEra) -> m ()
+addStakeWitnessWithTxBody :: (MonadBuildTx era m, C.IsShelleyBasedEra era) => C.StakeCredential -> (TxBody era -> C.Witness C.WitCtxStake era) -> m ()
 addStakeWitnessWithTxBody credential buildWitness =
-  addTxBuilder (TxBuilder $ \body -> set (L.txCertificates . L._TxCertificates . _2 . at credential) (Just $ buildWitness body))
+  -- addTxBuilder (TxBuilder $ \body -> set (L.txCertificates . L._TxCertificates . _2 . at credential) ())
+  addTxBuilder (TxBuilder $ \body -> over (L.txCertificates . L._TxCertificates . _2) ((:) (credential, buildWitness body)))
 
 {-| Spend an output locked by a public key
 -}
-spendPublicKeyOutput :: MonadBuildTx m => C.TxIn -> m ()
+spendPublicKeyOutput :: MonadBuildTx era m => C.TxIn -> m ()
 spendPublicKeyOutput txIn = do
   let wit = C.BuildTxWith (C.KeyWitness C.KeyWitnessForSpending)
   addBtx (over L.txIns ((txIn, wit) :))
 
 {-| Utility function to build a v1 script witness
 -}
-buildV1ScriptWitness :: forall redeemer witctx . Plutus.ToData redeemer =>
-  C.PlutusScript C.PlutusScriptV1 ->
+buildScriptWitness ::
+  (Plutus.ToData redeemer, C.HasScriptLanguageInEra lang era, C.IsPlutusScriptLanguage lang) =>
+  C.PlutusScript lang ->
   C.ScriptDatum witctx ->
   redeemer ->
-  C.ScriptWitness witctx C.ConwayEra
-buildV1ScriptWitness script datum redeemer =
+  C.ScriptWitness witctx era
+buildScriptWitness script datum redeemer =
   C.PlutusScriptWitness
-    C.PlutusScriptV1InConway
-    C.PlutusScriptV1
-    (C.PScript script)
-    datum
-    (toHashableScriptData redeemer)
-    (C.ExecutionUnits 0 0)
-
-{-| Utility function to build a v2 script witness
--}
-buildV2ScriptWitness :: forall redeemer witctx . Plutus.ToData redeemer =>
-  C.PlutusScript C.PlutusScriptV2 ->
-  C.ScriptDatum witctx ->
-  redeemer ->
-  C.ScriptWitness witctx C.ConwayEra
-buildV2ScriptWitness script datum redeemer =
-  C.PlutusScriptWitness
-    C.PlutusScriptV2InConway
-    C.PlutusScriptV2
+    C.scriptLanguageInEra
+    C.plutusScriptVersion
     (C.PScript script)
     datum
     (toHashableScriptData redeemer)
@@ -392,77 +360,87 @@ buildV2ScriptWitness script datum redeemer =
 
 {-| Utility function to build a reference script witness
 -}
-buildV2RefScriptWitness :: forall redeemer witctx . Plutus.ToData redeemer =>
+buildRefScriptWitness ::
+  (Plutus.ToData redeemer, C.HasScriptLanguageInEra lang era) =>
   C.TxIn ->
-  Maybe C.ScriptHash ->
+  C.PlutusScriptVersion lang ->
   C.ScriptDatum witctx ->
   redeemer ->
-  C.ScriptWitness witctx C.ConwayEra
-buildV2RefScriptWitness refTxIn mbSh datum redeemer =
+  C.ScriptWitness witctx era
+buildRefScriptWitness refTxIn scrVer datum redeemer =
   C.PlutusScriptWitness
-    C.PlutusScriptV2InConway
-    C.PlutusScriptV2
-    (C.PReferenceScript refTxIn mbSh)
+    C.scriptLanguageInEra
+    scrVer
+    (C.PReferenceScript refTxIn Nothing)
     datum
     (toHashableScriptData redeemer)
     (C.ExecutionUnits 0 0)
 
-spendPlutusV1 :: forall datum redeemer m. (MonadBuildTx m, Plutus.ToData datum, Plutus.ToData redeemer) => C.TxIn -> PlutusScript PlutusScriptV1 -> datum -> redeemer -> m ()
-spendPlutusV1 txIn s (toHashableScriptData -> dat) red =
-  let wit = C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending $ buildV1ScriptWitness s (C.ScriptDatumForTxIn $ Just dat) red
-  in setScriptsValid >> addBtx (over L.txIns ((txIn, wit) :))
-
-spendPlutusV2 :: forall datum redeemer m. (MonadBuildTx m, Plutus.ToData datum, Plutus.ToData redeemer) => C.TxIn -> PlutusScript PlutusScriptV2 -> datum -> redeemer -> m ()
-spendPlutusV2 txIn s (toHashableScriptData -> dat) red =
-  let wit = C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending $ buildV2ScriptWitness s (C.ScriptDatumForTxIn $ Just dat) red
+spendPlutus :: forall datum redeemer era lang m.
+  (MonadBuildTx era m, Plutus.ToData datum, Plutus.ToData redeemer, C.IsAlonzoBasedEra era, C.HasScriptLanguageInEra lang era, C.IsPlutusScriptLanguage lang)
+  => C.TxIn -> PlutusScript lang -> datum -> redeemer -> m ()
+spendPlutus txIn s (toHashableScriptData -> dat) red =
+  let wit = C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending $ buildScriptWitness s (C.ScriptDatumForTxIn $ Just dat) red
   in setScriptsValid >> addBtx (over L.txIns ((txIn, wit) :))
 
 {-| Spend an output locked by a Plutus V2 validator with an inline datum
 -}
-spendPlutusV2InlineDatum :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> PlutusScript PlutusScriptV2 -> redeemer -> m ()
-spendPlutusV2InlineDatum txIn s red =
-  let wit = C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending $ buildV2ScriptWitness s C.InlineScriptDatum red
+spendPlutusInlineDatum :: forall redeemer lang era m. (MonadBuildTx era m, Plutus.ToData redeemer, C.IsAlonzoBasedEra era, C.HasScriptLanguageInEra lang era, C.IsPlutusScriptLanguage lang)
+  => C.TxIn -> PlutusScript lang -> redeemer -> m ()
+spendPlutusInlineDatum txIn s red =
+  let wit = C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending $ buildScriptWitness s C.InlineScriptDatum red
   in setScriptsValid >> addBtx (over L.txIns ((txIn, wit) :))
 
 {-| Spend an output locked by a Plutus V2 validator using the redeemer provided. The redeemer
 can depend on the index of the @TxIn@ in the inputs of the final transaction.
 -}
-spendPlutusV2RefBase :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> C.ScriptDatum C.WitCtxTxIn -> (Int -> redeemer) -> m ()
-spendPlutusV2RefBase txIn refTxIn sh dat red =
-  let wit txBody = C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending $ buildV2RefScriptWitness refTxIn sh dat (red $ findIndexSpending txIn txBody)
+spendPlutusRefBase :: forall redeemer lang era m. (MonadBuildTx era m, Plutus.ToData redeemer, C.IsAlonzoBasedEra era, C.HasScriptLanguageInEra lang era)
+  => C.TxIn -> C.TxIn -> C.PlutusScriptVersion lang -> C.ScriptDatum C.WitCtxTxIn -> (Int -> redeemer) -> m ()
+spendPlutusRefBase txIn refTxIn scrVer dat red =
+  let wit txBody = C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending $ buildRefScriptWitness refTxIn scrVer dat (red $ findIndexSpending txIn txBody)
   in setScriptsValid >> addTxBuilder (TxBuilder $ \body -> over L.txIns ((txIn, wit body) :))
 
 {-| Spend an output locked by a Plutus V2 validator using the redeemer
 -}
-spendPlutusV2RefBaseWithInRef :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> C.ScriptDatum C.WitCtxTxIn -> redeemer -> m ()
-spendPlutusV2RefBaseWithInRef txIn refTxIn sh dat red = spendPlutusV2RefBase txIn refTxIn sh dat (const red) >> addReference refTxIn
+spendPlutusRefBaseWithInRef :: forall redeemer lang era m. (MonadBuildTx era m, Plutus.ToData redeemer, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra lang era)
+  => C.TxIn -> C.TxIn -> C.PlutusScriptVersion lang -> C.ScriptDatum C.WitCtxTxIn -> redeemer -> m ()
+spendPlutusRefBaseWithInRef txIn refTxIn scrVer dat red = inBabbage @era spendPlutusRefBase txIn refTxIn scrVer dat (const red) >> addReference refTxIn
 
-spendPlutusV2Ref :: forall datum redeemer m. (MonadBuildTx m, Plutus.ToData datum, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> datum -> redeemer -> m ()
-spendPlutusV2Ref txIn refTxIn sh (toHashableScriptData -> dat) = spendPlutusV2RefBaseWithInRef txIn refTxIn sh (C.ScriptDatumForTxIn $ Just dat)
+spendPlutusRef :: forall datum redeemer lang era m. (MonadBuildTx era m, Plutus.ToData datum, Plutus.ToData redeemer, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra lang era)
+  => C.TxIn -> C.TxIn -> C.PlutusScriptVersion lang -> datum -> redeemer -> m ()
+spendPlutusRef txIn refTxIn scrVer (toHashableScriptData -> dat) = spendPlutusRefBaseWithInRef txIn refTxIn scrVer (C.ScriptDatumForTxIn $ Just dat)
 
 {-| same as spendPlutusV2Ref but considers inline datum at the spent utxo
 -}
-spendPlutusV2RefWithInlineDatum :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> redeemer -> m ()
-spendPlutusV2RefWithInlineDatum txIn refTxIn sh = spendPlutusV2RefBaseWithInRef txIn refTxIn sh C.InlineScriptDatum
+spendPlutusRefWithInlineDatum :: forall redeemer lang era m.
+  (MonadBuildTx era m, Plutus.ToData redeemer, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra lang era)
+  => C.TxIn -> C.TxIn -> C.PlutusScriptVersion lang -> redeemer -> m ()
+spendPlutusRefWithInlineDatum txIn refTxIn scrVer = spendPlutusRefBaseWithInRef txIn refTxIn scrVer C.InlineScriptDatum
 
 {-| same as spendPlutusV2Ref but does not add the reference script in the reference input list
 This is to cover the case whereby the reference script utxo is expected to be consumed in the same tx.
 -}
-spendPlutusV2RefWithoutInRef :: forall datum redeemer m. (MonadBuildTx m, Plutus.ToData datum, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> datum -> redeemer -> m ()
-spendPlutusV2RefWithoutInRef txIn refTxIn sh (toHashableScriptData -> dat) red = spendPlutusV2RefBase txIn refTxIn sh (C.ScriptDatumForTxIn $ Just dat) (const red)
+spendPlutusRefWithoutInRef :: forall datum redeemer lang era m.
+  (MonadBuildTx era m, Plutus.ToData datum, Plutus.ToData redeemer, C.IsAlonzoBasedEra era, C.HasScriptLanguageInEra lang era)
+  => C.TxIn -> C.TxIn -> C.PlutusScriptVersion lang -> datum -> redeemer -> m ()
+spendPlutusRefWithoutInRef txIn refTxIn scrVer (toHashableScriptData -> dat) red = spendPlutusRefBase txIn refTxIn scrVer (C.ScriptDatumForTxIn $ Just dat) (const red)
 
 {-| same as spendPlutusV2RefWithoutInRef but considers inline datum at the spent utxo
 -}
-spendPlutusV2RefWithoutInRefInlineDatum :: forall redeemer m. (MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> C.TxIn -> Maybe C.ScriptHash -> redeemer -> m ()
-spendPlutusV2RefWithoutInRefInlineDatum txIn refTxIn sh red = spendPlutusV2RefBase txIn refTxIn sh C.InlineScriptDatum (const red)
+spendPlutusRefWithoutInRefInlineDatum :: forall redeemer lang era m.
+  (MonadBuildTx era m, Plutus.ToData redeemer, C.IsAlonzoBasedEra era, C.HasScriptLanguageInEra lang era)
+  => C.TxIn -> C.TxIn -> C.PlutusScriptVersion lang -> redeemer -> m ()
+spendPlutusRefWithoutInRefInlineDatum txIn refTxIn scrVer red = spendPlutusRefBase txIn refTxIn scrVer C.InlineScriptDatum (const red)
 
-mintPlutusV1 :: forall redeemer m. (Plutus.ToData redeemer, MonadBuildTx m) => PlutusScript PlutusScriptV1 -> redeemer -> C.AssetName -> C.Quantity -> m ()
-mintPlutusV1 script red assetName quantity =
-  let sh = C.hashScript (C.PlutusScript C.PlutusScriptV1 script)
+mintPlutus :: forall redeemer lang era m. (Plutus.ToData redeemer, MonadBuildTx era m, C.HasScriptLanguageInEra lang era, C.IsAlonzoBasedEra era, C.IsPlutusScriptLanguage lang) => PlutusScript lang -> redeemer -> C.AssetName -> C.Quantity -> m ()
+mintPlutus script red assetName quantity =
+  let sh = C.hashScript (C.PlutusScript C.plutusScriptVersion script)
       v = assetValue sh assetName quantity
       policyId = C.PolicyId sh
-      wit      = buildV1ScriptWitness script C.NoScriptDatumForMint red
-  in  setScriptsValid >> addBtx (over (L.txMintValue . L._TxMintValue) (over _1 (<> v) . over _2 (Map.insert policyId wit)))
+      wit      = buildScriptWitness script C.NoScriptDatumForMint red
+  in
+    inAlonzo @era $
+    setScriptsValid >> addBtx (over (L.txMintValue . L._TxMintValue) (over _1 (<> v) . over _2 (Map.insert policyId wit)))
 
 {-| A value containing the given amount of the native asset
 -}
@@ -470,114 +448,111 @@ assetValue :: ScriptHash -> C.AssetName -> C.Quantity -> C.Value
 assetValue hsh assetName quantity =
   C.valueFromList [(C.AssetId (C.PolicyId hsh) assetName, quantity)]
 
-mintPlutusV2 :: forall redeemer m. (Plutus.ToData redeemer, MonadBuildTx m) => PlutusScript PlutusScriptV2 -> redeemer -> C.AssetName -> C.Quantity -> m ()
-mintPlutusV2 script red assetName quantity =
-  let sh = C.hashScript (C.PlutusScript C.PlutusScriptV2 script)
-      v = assetValue sh assetName quantity
-      policyId = C.PolicyId sh
-      wit      = buildV2ScriptWitness script C.NoScriptDatumForMint red
-  in  setScriptsValid >> addBtx (over (L.txMintValue . L._TxMintValue) (over _1 (<> v) . over _2 (Map.insert policyId wit)))
-
-mintPlutusV2Ref :: forall redeemer m. (Plutus.ToData redeemer, MonadBuildTx m) => C.TxIn -> C.ScriptHash -> redeemer -> C.AssetName -> C.Quantity -> m ()
-mintPlutusV2Ref refTxIn sh red assetName quantity =
+mintPlutusRef :: forall redeemer lang era m.
+  (Plutus.ToData redeemer, MonadBuildTx era m, C.HasScriptLanguageInEra lang era, C.IsBabbageBasedEra era)
+  => C.TxIn -> C.PlutusScriptVersion lang -> C.ScriptHash -> redeemer -> C.AssetName -> C.Quantity -> m ()
+mintPlutusRef refTxIn scrVer sh red assetName quantity = inBabbage @era $
   let v = assetValue sh assetName quantity
-      wit = buildV2RefScriptWitness refTxIn (Just sh) C.NoScriptDatumForMint red
+      wit = buildRefScriptWitness refTxIn scrVer C.NoScriptDatumForMint red
       policyId = C.PolicyId sh
   in  setScriptsValid
       >> addBtx (over (L.txMintValue . L._TxMintValue) (over _1 (<> v) . over _2 (Map.insert policyId wit)))
       >> addReference refTxIn
 
-mintSimpleScriptAssets :: MonadBuildTx m => C.SimpleScript -> [(C.AssetName, C.Quantity)] -> m ()
-mintSimpleScriptAssets sscript assets =
-  let wit = C.SimpleScriptWitness C.SimpleScriptInConway (C.SScript sscript)
+mintSimpleScriptAssets :: forall era m. (MonadBuildTx era m, C.IsMaryBasedEra era) => C.SimpleScript -> [(C.AssetName, C.Quantity)] -> m ()
+mintSimpleScriptAssets sscript assets = inMary @era $
+  let wit = C.SimpleScriptWitness simpleScriptInShelleyEra (C.SScript sscript)
       policyId = C.scriptPolicyId . C.SimpleScript $ sscript
   in traverse_ (\(an,q) -> addMintWithTxBody policyId an q (const wit)) assets
 
-spendSimpleScript :: MonadBuildTx m => C.TxIn -> C.SimpleScript -> m ()
+spendSimpleScript :: (MonadBuildTx era m, C.IsShelleyBasedEra era) => C.TxIn -> C.SimpleScript -> m ()
 spendSimpleScript txIn sscript =
-  let wit = C.SimpleScriptWitness C.SimpleScriptInConway (C.SScript sscript)
+  let wit = C.SimpleScriptWitness simpleScriptInShelleyEra (C.SScript sscript)
   in addBtx (over L.txIns ((txIn, C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending wit) :))
 
-addCollateral :: MonadBuildTx m => C.TxIn -> m ()
-addCollateral i = addBtx $ over (L.txInsCollateral . L._TxInsCollateralIso) ((:) i)
+addCollateral :: (MonadBuildTx era m, C.IsAlonzoBasedEra era) => C.TxIn -> m ()
+addCollateral i = addBtx $ over (L.txInsCollateral . L._TxInsCollateralIso) (i :)
 
-addReference :: MonadBuildTx m => C.TxIn -> m ()
-addReference i = addBtx $ over (L.txInsReference . L._TxInsReferenceIso) ((:) i)
+addReference :: (MonadBuildTx era m, C.IsBabbageBasedEra era) => C.TxIn -> m ()
+addReference i = addBtx $ over (L.txInsReference . L._TxInsReferenceIso) (i :)
 
-addAuxScript :: MonadBuildTx m => C.ScriptInEra C.ConwayEra -> m ()
-addAuxScript s = addBtx (over (L.txAuxScripts . L._TxAuxScripts) ((:) s))
+addAuxScript :: (MonadBuildTx era m, C.IsAllegraBasedEra era) => C.ScriptInEra era -> m ()
+addAuxScript s = addBtx (over (L.txAuxScripts . L._TxAuxScripts) (s :))
 
-payToAddressTxOut :: C.AddressInEra C.ConwayEra -> C.Value -> C.TxOut C.CtxTx C.ConwayEra
-payToAddressTxOut addr vl = C.TxOut addr (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue vl) C.TxOutDatumNone C.ReferenceScriptNone
+payToAddressTxOut :: C.IsMaryBasedEra era => C.AddressInEra era -> C.Value -> C.TxOut C.CtxTx era
+payToAddressTxOut addr vl =
+  C.TxOut
+  addr
+  (mkTxOutValue vl)
+  C.TxOutDatumNone
+  C.ReferenceScriptNone
 
-payToAddress :: MonadBuildTx m => C.AddressInEra C.ConwayEra -> C.Value -> m ()
-payToAddress addr vl = addBtx $ over L.txOuts ((:) (payToAddressTxOut addr vl))
+payToAddress :: (MonadBuildTx era m, C.IsMaryBasedEra era) => C.AddressInEra era -> C.Value -> m ()
+payToAddress addr vl = addBtx $ over L.txOuts (payToAddressTxOut addr vl :)
 
-payToPublicKey :: MonadBuildTx m => NetworkId -> Hash PaymentKey -> C.Value -> m ()
+payToPublicKey :: (MonadBuildTx era m, C.IsMaryBasedEra era) => NetworkId -> Hash PaymentKey -> C.Value -> m ()
 payToPublicKey network pk vl =
-  let val = C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue vl
-      addr = C.makeShelleyAddressInEra C.ShelleyBasedEraConway network (C.PaymentCredentialByKey pk) C.NoStakeAddress
+  let val = mkTxOutValue vl
+      addr = C.makeShelleyAddressInEra (C.maryEraOnwardsToShelleyBasedEra C.maryBasedEra) network (C.PaymentCredentialByKey pk) C.NoStakeAddress
       txo = C.TxOut addr val C.TxOutDatumNone C.ReferenceScriptNone
-  in prependTxOut txo
+  in addOutput txo
 
-payToScriptHash :: MonadBuildTx m => NetworkId -> ScriptHash -> HashableScriptData -> C.StakeAddressReference -> C.Value -> m ()
-payToScriptHash network script datum stakeAddress vl =
-  let val = C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue vl
-      addr = C.makeShelleyAddressInEra C.ShelleyBasedEraConway network (C.PaymentCredentialByScript script) stakeAddress
-      dat = C.TxOutDatumInTx C.AlonzoEraOnwardsConway datum
+payToScriptHash :: forall era m. (MonadBuildTx era m, C.IsAlonzoBasedEra era) => NetworkId -> ScriptHash -> HashableScriptData -> C.StakeAddressReference -> C.Value -> m ()
+payToScriptHash network script datum stakeAddress vl = inAlonzo @era $
+  let val = mkTxOutValue vl
+      addr = C.makeShelleyAddressInEra C.shelleyBasedEra network (C.PaymentCredentialByScript script) stakeAddress
+      dat = C.TxOutDatumInTx C.alonzoBasedEra datum
       txo = C.TxOut addr val dat C.ReferenceScriptNone
-  in prependTxOut txo
+  in addOutput txo
 
-payToPlutusV1 :: forall a m. (MonadBuildTx m, Plutus.ToData a) => NetworkId -> PlutusScript PlutusScriptV1 -> a -> C.StakeAddressReference -> C.Value -> m ()
-payToPlutusV1 network s datum stakeRef vl =
-  let sh = C.hashScript (C.PlutusScript C.PlutusScriptV1 s)
+payToScriptDatumHash :: forall a lang era m.
+  (MonadBuildTx era m, Plutus.ToData a, C.IsAlonzoBasedEra era)
+  => NetworkId -> C.Script lang -> a -> C.StakeAddressReference -> C.Value -> m ()
+payToScriptDatumHash network s datum stakeRef vl =
+  let sh = C.hashScript s
       dt = toHashableScriptData datum
   in payToScriptHash network sh dt stakeRef vl
 
-payToPlutusV2 :: forall a m. (MonadBuildTx m, Plutus.ToData a) => NetworkId -> PlutusScript PlutusScriptV2 -> a -> C.StakeAddressReference -> C.Value -> m ()
-payToPlutusV2 network s datum stakeRef vl =
-  let sh = C.hashScript (C.PlutusScript C.PlutusScriptV2 s)
-      dt = toHashableScriptData datum
-  in payToScriptHash network sh dt stakeRef vl
+createRefScriptBase :: forall lang era m. (MonadBuildTx era m, C.IsBabbageBasedEra era, C.IsScriptLanguage lang)
+  => C.AddressInEra era -> C.Script lang -> C.TxOutDatum C.CtxTx era -> C.Value -> m ()
+createRefScriptBase addr script dat vl = inBabbage @era $
+  let refScript = C.ReferenceScript C.babbageBasedEra $ C.ScriptInAnyLang C.scriptLanguage script
+      txo = C.TxOut addr (mkTxOutValue vl) dat refScript
+  in addOutput txo
 
-payToPlutusV2InlineBase :: MonadBuildTx m => C.AddressInEra C.ConwayEra -> C.PlutusScript C.PlutusScriptV2 -> C.TxOutDatum C.CtxTx C.ConwayEra -> C.Value -> m ()
-payToPlutusV2InlineBase addr script dat vl =
-  let refScript = C.ReferenceScript C.BabbageEraOnwardsConway (C.toScriptInAnyLang $ C.PlutusScript C.PlutusScriptV2 script)
-      txo = C.TxOut addr (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue vl) dat refScript
-  in prependTxOut txo
-
-payToPlutusV2Inline :: MonadBuildTx m => C.AddressInEra C.ConwayEra -> PlutusScript PlutusScriptV2 -> C.Value -> m ()
-payToPlutusV2Inline addr script = payToPlutusV2InlineBase addr script C.TxOutDatumNone
+createRefScriptNoDatum :: (MonadBuildTx era m, C.IsBabbageBasedEra era, C.IsScriptLanguage lang) => C.AddressInEra era -> C.Script lang -> C.Value -> m ()
+createRefScriptNoDatum addr script = createRefScriptBase addr script C.TxOutDatumNone
 
 {-| same as payToPlutusV2Inline but also specify an inline datum -}
-payToPlutusV2InlineWithInlineDatum :: forall a m. (MonadBuildTx m, Plutus.ToData a) => C.AddressInEra C.ConwayEra -> C.PlutusScript C.PlutusScriptV2 -> a -> C.Value -> m ()
-payToPlutusV2InlineWithInlineDatum addr script datum vl =
-  let dat = C.TxOutDatumInline C.BabbageEraOnwardsConway (toHashableScriptData datum)
-  in payToPlutusV2InlineBase addr script dat vl
+createRefScriptInlineDatum :: forall a lang era m. (MonadBuildTx era m, Plutus.ToData a, C.IsBabbageBasedEra era, C.IsScriptLanguage lang)
+  => C.AddressInEra era -> C.Script lang -> a -> C.Value -> m ()
+createRefScriptInlineDatum addr script datum vl =
+  let dat = C.TxOutDatumInline C.babbageBasedEra (toHashableScriptData datum)
+  in createRefScriptBase addr script dat vl
 
 {-| same as payToPlutusV2Inline but also specify a datum -}
-payToPlutusV2InlineWithDatum :: forall a m. (MonadBuildTx m, Plutus.ToData a) => C.AddressInEra C.ConwayEra -> C.PlutusScript C.PlutusScriptV2 -> a -> C.Value -> m ()
-payToPlutusV2InlineWithDatum addr script datum vl =
-  let dat = C.TxOutDatumInTx C.AlonzoEraOnwardsConway (toHashableScriptData datum)
-  in payToPlutusV2InlineBase addr script dat vl
+createRefScriptDatumHash :: forall a lang era m. (MonadBuildTx era m, Plutus.ToData a, C.IsBabbageBasedEra era, C.IsScriptLanguage lang)
+  => C.AddressInEra era -> C.Script lang -> a -> C.Value -> m ()
+createRefScriptDatumHash addr script datum vl =
+  let dat = C.TxOutDatumInTx (C.babbageEraOnwardsToAlonzoEraOnwards C.babbageBasedEra) (toHashableScriptData datum)
+  in createRefScriptBase addr script dat vl
 
-payToPlutusV2InlineDatum :: forall a m. (MonadBuildTx m, Plutus.ToData a) => NetworkId -> PlutusScript PlutusScriptV2 -> a -> C.StakeAddressReference -> C.Value -> m ()
-payToPlutusV2InlineDatum network script datum stakeRef vl =
-  let val = C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue vl
-      sh  = C.hashScript (C.PlutusScript C.PlutusScriptV2 script)
-      addr = C.makeShelleyAddressInEra C.ShelleyBasedEraConway network (C.PaymentCredentialByScript sh) stakeRef
-      dat = C.TxOutDatumInline C.BabbageEraOnwardsConway (toHashableScriptData datum)
+payToScriptInlineDatum :: forall a era m. (MonadBuildTx era m, Plutus.ToData a, C.IsBabbageBasedEra era) => NetworkId -> C.ScriptHash -> a -> C.StakeAddressReference -> C.Value -> m ()
+payToScriptInlineDatum network sh datum stakeRef vl = inBabbage @era $
+  let val = mkTxOutValue vl
+      addr = C.makeShelleyAddressInEra C.shelleyBasedEra network (C.PaymentCredentialByScript sh) stakeRef
+      dat = C.TxOutDatumInline C.babbageBasedEra (toHashableScriptData datum)
       txo = C.TxOut addr val dat C.ReferenceScriptNone
-  in prependTxOut txo
+  in addOutput txo
 -- TODO: Functions for building outputs (Output -> Output)
 
-setScriptsValid :: MonadBuildTx m => m ()
-setScriptsValid = addBtx $ set L.txScriptValidity (C.TxScriptValidity C.AlonzoEraOnwardsConway C.ScriptValid)
+setScriptsValid :: C.IsAlonzoBasedEra era => MonadBuildTx era m => m ()
+setScriptsValid = addBtx $ set L.txScriptValidity (C.TxScriptValidity C.alonzoBasedEra C.ScriptValid)
 
 {-| Set the Ada component in an output's value to at least the amount needed to cover the
 minimum UTxO deposit for this output
 -}
-setMinAdaDeposit :: C.LedgerProtocolParameters C.ConwayEra -> C.TxOut C.CtxTx C.ConwayEra -> C.TxOut C.CtxTx C.ConwayEra
+setMinAdaDeposit :: C.IsMaryBasedEra era => C.LedgerProtocolParameters era -> C.TxOut C.CtxTx era -> C.TxOut C.CtxTx era
 setMinAdaDeposit params txOut =
   let minUtxo = minAdaDeposit params txOut
   in txOut & over (L._TxOut . _2 . L._TxOutValue . L._Value . at C.AdaAssetId) (maybe (Just minUtxo) (Just . max minUtxo))
@@ -585,43 +560,39 @@ setMinAdaDeposit params txOut =
 {-| Calculate the minimum amount of Ada that must be locked in the given UTxO to
 satisfy the ledger's minimum Ada constraint.
 -}
-minAdaDeposit :: C.LedgerProtocolParameters C.ConwayEra -> C.TxOut C.CtxTx C.ConwayEra -> C.Quantity
+minAdaDeposit :: C.IsMaryBasedEra era => C.LedgerProtocolParameters era -> C.TxOut C.CtxTx era -> C.Quantity
 minAdaDeposit (C.LedgerProtocolParameters params) txOut =
   let minAdaValue = C.Quantity 3_000_000
       txo = txOut
             -- set the Ada value to a dummy amount to ensure that it is not 0 (if it was 0, the size of the output
             -- would be smaller, causing 'calculateMinimumUTxO' to compute an amount that is a little too small)
             & over (L._TxOut . _2 . L._TxOutValue . L._Value . at C.AdaAssetId) (maybe (Just minAdaValue) (Just . max minAdaValue))
-  in fromMaybe (C.Quantity 0) $ do
-        let l  = C.calculateMinimumUTxO C.ShelleyBasedEraConway txo params
-            -- dummyTxIn = C.TxIn "abc" (C.TxIx 0)
-            -- l2 = Core.getMinCoinTxOut params (_ $ C.toLedgerUTxO C.ShelleyBasedEraConway $ C.UTxO $ Map.singleton dummyTxIn $ C.toCtxUTxOTxOut txo)
-        pure (C.lovelaceToQuantity l)
+  in C.lovelaceToQuantity $ C.calculateMinimumUTxO (C.maryEraOnwardsToShelleyBasedEra C.maryBasedEra) txo params
 
 {-| Apply 'setMinAdaDeposit' to all outputs
 -}
-setMinAdaDepositAll :: MonadBuildTx m => C.LedgerProtocolParameters C.ConwayEra -> m ()
+setMinAdaDepositAll :: (MonadBuildTx era m, C.IsMaryBasedEra era) => C.LedgerProtocolParameters era -> m ()
 setMinAdaDepositAll params = addBtx $ over (L.txOuts . mapped) (setMinAdaDeposit params)
 
 {-| Add a public key hash to the list of required signatures.
 -}
-addRequiredSignature :: MonadBuildTx m => Hash PaymentKey -> m ()
+addRequiredSignature :: (MonadBuildTx era m, C.IsAlonzoBasedEra era) => Hash PaymentKey -> m ()
 addRequiredSignature sig =
   addBtx $ over (L.txExtraKeyWits . L._TxExtraKeyWitnesses) (nub . (:) sig)
 
 {-| Add a transaction output to the start of the list of transaction outputs.
 -}
-prependTxOut :: MonadBuildTx m => C.TxOut C.CtxTx C.ConwayEra -> m ()
+prependTxOut :: MonadBuildTx era m => C.TxOut C.CtxTx era -> m ()
 prependTxOut txOut = addBtx (over L.txOuts ((:) txOut))
 
 {-| Add a transaction output to the end of the list of transaction outputs.
 -}
-addOutput :: MonadBuildTx m => C.TxOut C.CtxTx C.ConwayEra -> m ()
-addOutput txOut = addBtx (over (L.txOuts . L.reversed) ((:) txOut))
+addOutput :: MonadBuildTx era m => C.TxOut C.CtxTx era -> m ()
+addOutput txOut = addBtx (over (L.txOuts . L.reversed) (txOut :))
 
 {-| Add a stake rewards withdrawal to the transaction
 -}
-addWithdrawal :: MonadBuildTx m => C.StakeAddress -> C.Quantity -> C.Witness C.WitCtxStake C.ConwayEra -> m ()
+addWithdrawal :: (MonadBuildTx era m, C.IsShelleyBasedEra era) => C.StakeAddress -> C.Quantity -> C.Witness C.WitCtxStake era -> m ()
 addWithdrawal address amount witness =
   let withdrawal = (address, C.quantityToLovelace amount, C.BuildTxWith witness)
   in addBtx (over (L.txWithdrawals . L._TxWithdrawals) ((:) withdrawal))
@@ -629,7 +600,7 @@ addWithdrawal address amount witness =
 {- Like `addWithdrawal` but the stake address is built from the supplied script hash. This is an utility to make withdrawals guarded by
 scripts easier to trigger
 -}
-addScriptWithdrawal :: (MonadBlockchain m, MonadBuildTx m) => ScriptHash -> C.Quantity -> C.ScriptWitness C.WitCtxStake C.ConwayEra -> m ()
+addScriptWithdrawal :: (MonadBlockchain era m, MonadBuildTx era m, C.IsShelleyBasedEra era) => ScriptHash -> C.Quantity -> C.ScriptWitness C.WitCtxStake era -> m ()
 addScriptWithdrawal sh quantity witness = do
   n <- queryNetworkId
   let addr = C.StakeAddress (C.toShelleyNetwork n) $ C.toShelleyStakeCredential $ C.StakeCredentialByScript sh
@@ -639,37 +610,42 @@ addScriptWithdrawal sh quantity witness = do
 {-| Add a withdrawal of 0 Lovelace from the rewards account locked by the given Plutus V2 script.
 Includes the script in the transaction.
 -}
-addWithdrawZeroPlutusV2InTransaction :: (MonadBlockchain m, MonadBuildTx m, Plutus.ToData redeemer) => PlutusScript PlutusScriptV2 -> redeemer -> m ()
+addWithdrawZeroPlutusV2InTransaction
+  :: (MonadBlockchain era m, MonadBuildTx era m, C.HasScriptLanguageInEra PlutusScriptV2 era, Plutus.ToData redeemer, C.IsShelleyBasedEra era)
+  => PlutusScript PlutusScriptV2 -> redeemer -> m ()
 addWithdrawZeroPlutusV2InTransaction script redeemer = do
   let sh = C.hashScript $ C.PlutusScript C.PlutusScriptV2 script
-  addScriptWithdrawal sh 0 $ buildV2ScriptWitness script C.NoScriptDatumForStake redeemer
+  addScriptWithdrawal sh 0 $ buildScriptWitness script C.NoScriptDatumForStake redeemer
 
 {-| Add a withdrawal of 0 Lovelace from the rewards account locked by the given Plutus V2 script.
 The script is provided as a reference input.
 -}
-addWithdrawZeroPlutusV2Reference :: (MonadBlockchain m, MonadBuildTx m, Plutus.ToData redeemer) => C.TxIn -> ScriptHash -> redeemer -> m ()
-addWithdrawZeroPlutusV2Reference refTxIn script redeemer = addScriptWithdrawal script 0 $ buildV2RefScriptWitness refTxIn (Just script) C.NoScriptDatumForStake redeemer
+addWithdrawZeroPlutusV2Reference
+  :: (MonadBlockchain era m, MonadBuildTx era m, Plutus.ToData redeemer, C.HasScriptLanguageInEra PlutusScriptV2 era, C.IsShelleyBasedEra era)
+  => C.TxIn -> ScriptHash -> redeemer -> m ()
+addWithdrawZeroPlutusV2Reference refTxIn script redeemer = addScriptWithdrawal script 0 $ buildRefScriptWitness refTxIn C.PlutusScriptV2 C.NoScriptDatumForStake redeemer
 
 {-| Add a certificate (stake delegation, stake pool registration, etc)
 to the transaction
 -}
-addCertificate :: MonadBuildTx m => C.Certificate C.ConwayEra -> m ()
+addCertificate :: (MonadBuildTx era m, C.IsShelleyBasedEra era) => C.Certificate era -> m ()
 addCertificate cert =
   addBtx (over (L.txCertificates . L._TxCertificates . _1) ((:) cert))
 
 {-| Add a 'C.StakeCredential' as a certificate to the transaction
 -}
-addStakeCredentialCertificate :: MonadBuildTx m => C.StakeCredential -> m ()
-addStakeCredentialCertificate =
-  addCertificate . C.ConwayCertificate C.conwayBasedEra . TxCert.RegTxCert . C.toShelleyStakeCredential
+addStakeCredentialCertificate :: forall era m. C.IsConwayBasedEra era => MonadBuildTx era m => C.StakeCredential -> m ()
+addStakeCredentialCertificate stk =
+  C.conwayEraOnwardsConstraints @era C.conwayBasedEra $
+  addCertificate $ C.ConwayCertificate C.conwayBasedEra $ TxCert.RegTxCert $ C.toShelleyStakeCredential stk
 
-addStakeCredentialUnregCertificate :: MonadBuildTx m => C.StakeCredential -> m ()
-addStakeCredentialUnregCertificate =
-  addCertificate . C.ConwayCertificate C.conwayBasedEra . TxCert.UnRegTxCert . C.toShelleyStakeCredential
-
+addStakeCredentialUnregCertificate :: forall era m. C.IsConwayBasedEra era => MonadBuildTx era m => C.StakeCredential -> m ()
+addStakeCredentialUnregCertificate stk =
+  C.conwayEraOnwardsConstraints @era C.conwayBasedEra $
+  addCertificate $ C.ConwayCertificate C.conwayBasedEra $ TxCert.UnRegTxCert $ C.toShelleyStakeCredential stk
 
 {-| Add a stake witness to the transaction
 -}
-addStakeWitness :: MonadBuildTx m => C.StakeCredential -> C.Witness C.WitCtxStake C.ConwayEra -> m ()
+addStakeWitness :: (MonadBuildTx era m, C.IsShelleyBasedEra era) => C.StakeCredential -> C.Witness C.WitCtxStake era -> m ()
 addStakeWitness credential witness =
-  addBtx (set (L.txCertificates . L._TxCertificates . _2 . at credential) (Just witness))
+  addBtx (over (L.txCertificates . L._TxCertificates . _2) ((:) (credential, witness)))

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -343,7 +343,7 @@ spendPublicKeyOutput txIn = do
 
 {-| Utility function to build a v1 script witness
 -}
-buildScriptWitness ::
+buildScriptWitness :: forall era lang redeemer witctx.
   (Plutus.ToData redeemer, C.HasScriptLanguageInEra lang era, C.IsPlutusScriptLanguage lang) =>
   C.PlutusScript lang ->
   C.ScriptDatum witctx ->
@@ -404,7 +404,7 @@ spendPlutusRefBase txIn refTxIn scrVer dat red =
 -}
 spendPlutusRefBaseWithInRef :: forall redeemer lang era m. (MonadBuildTx era m, Plutus.ToData redeemer, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra lang era)
   => C.TxIn -> C.TxIn -> C.PlutusScriptVersion lang -> C.ScriptDatum C.WitCtxTxIn -> redeemer -> m ()
-spendPlutusRefBaseWithInRef txIn refTxIn scrVer dat red = inBabbage @era spendPlutusRefBase txIn refTxIn scrVer dat (const red) >> addReference refTxIn
+spendPlutusRefBaseWithInRef txIn refTxIn scrVer dat red = inBabbage @era $ spendPlutusRefBase txIn refTxIn scrVer dat (const red) >> addReference refTxIn
 
 spendPlutusRef :: forall datum redeemer lang era m. (MonadBuildTx era m, Plutus.ToData datum, Plutus.ToData redeemer, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra lang era)
   => C.TxIn -> C.TxIn -> C.PlutusScriptVersion lang -> datum -> redeemer -> m ()
@@ -437,7 +437,7 @@ mintPlutus script red assetName quantity =
   let sh = C.hashScript (C.PlutusScript C.plutusScriptVersion script)
       v = assetValue sh assetName quantity
       policyId = C.PolicyId sh
-      wit      = buildScriptWitness script C.NoScriptDatumForMint red
+      wit      = buildScriptWitness @era script C.NoScriptDatumForMint red
   in
     inAlonzo @era $
     setScriptsValid >> addBtx (over (L.txMintValue . L._TxMintValue) (over _1 (<> v) . over _2 (Map.insert policyId wit)))

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -331,7 +331,6 @@ addWithdrawalWithTxBody address amount f =
 -}
 addStakeWitnessWithTxBody :: (MonadBuildTx era m, C.IsShelleyBasedEra era) => C.StakeCredential -> (TxBody era -> C.Witness C.WitCtxStake era) -> m ()
 addStakeWitnessWithTxBody credential buildWitness =
-  -- addTxBuilder (TxBuilder $ \body -> set (L.txCertificates . L._TxCertificates . _2 . at credential) ())
   addTxBuilder (TxBuilder $ \body -> over (L.txCertificates . L._TxCertificates . _2) ((:) (credential, buildWitness body)))
 
 {-| Spend an output locked by a public key
@@ -523,14 +522,14 @@ createRefScriptBase addr script dat vl = inBabbage @era $
 createRefScriptNoDatum :: (MonadBuildTx era m, C.IsBabbageBasedEra era, C.IsScriptLanguage lang) => C.AddressInEra era -> C.Script lang -> C.Value -> m ()
 createRefScriptNoDatum addr script = createRefScriptBase addr script C.TxOutDatumNone
 
-{-| same as payToPlutusV2Inline but also specify an inline datum -}
+{-| same as createRefScriptBase but also specify an inline datum -}
 createRefScriptInlineDatum :: forall a lang era m. (MonadBuildTx era m, Plutus.ToData a, C.IsBabbageBasedEra era, C.IsScriptLanguage lang)
   => C.AddressInEra era -> C.Script lang -> a -> C.Value -> m ()
 createRefScriptInlineDatum addr script datum vl =
   let dat = C.TxOutDatumInline C.babbageBasedEra (toHashableScriptData datum)
   in createRefScriptBase addr script dat vl
 
-{-| same as payToPlutusV2Inline but also specify a datum -}
+{-| same as createRefScriptBase but also specify a datum -}
 createRefScriptDatumHash :: forall a lang era m. (MonadBuildTx era m, Plutus.ToData a, C.IsBabbageBasedEra era, C.IsScriptLanguage lang)
   => C.AddressInEra era -> C.Script lang -> a -> C.Value -> m ()
 createRefScriptDatumHash addr script datum vl =

--- a/src/base/lib/Convex/Class.hs
+++ b/src/base/lib/Convex/Class.hs
@@ -155,6 +155,7 @@ data ExUnitsError era =
 
 makePrisms ''ExUnitsError
 
+-- see https://github.com/j-mueller/sc-tools/issues/214
 data ValidationError era =
   ValidationErrorInMode !C.TxValidationErrorInCardanoMode
   | VExUnits !(ExUnitsError era)

--- a/src/base/lib/Convex/Class.hs
+++ b/src/base/lib/Convex/Class.hs
@@ -364,28 +364,28 @@ control over the capabilities they require.
 -- | A capability typeclass that provides methods for querying a chain indexer.
 --   See note [MonadUtxoQuery design].
 --   NOTE: There are currently no implementations of this class in sc-tools.
-class Monad m => MonadUtxoQuery era m | m -> era where
+class Monad m => MonadUtxoQuery m where
   -- | Given a set of payment credentials, retrieve all UTxOs associated with
   -- those payment credentials according to the current indexed blockchain
   -- state. Each UTXO also possibly has the resolved datum (meaning that if we
   -- only have the datum hash, the implementation should try and resolve it to
   -- the actual datum).
-  utxosByPaymentCredentials :: Set PaymentCredential -> m (UtxoSet C.CtxUTxO era (Maybe C.HashableScriptData))
+  utxosByPaymentCredentials :: Set PaymentCredential -> m (UtxoSet C.CtxUTxO (Maybe C.HashableScriptData))
 
-  default utxosByPaymentCredentials :: (MonadTrans t, m ~ t n, MonadUtxoQuery era n) => Set PaymentCredential -> m (UtxoSet C.CtxUTxO era (Maybe C.HashableScriptData))
+  default utxosByPaymentCredentials :: (MonadTrans t, m ~ t n, MonadUtxoQuery n) => Set PaymentCredential -> m (UtxoSet C.CtxUTxO (Maybe C.HashableScriptData))
   utxosByPaymentCredentials = lift . utxosByPaymentCredentials
 
-instance MonadUtxoQuery era m => MonadUtxoQuery era (ResultT m) where
-instance MonadUtxoQuery era m => MonadUtxoQuery era (ExceptT e m)
-instance MonadUtxoQuery era m => MonadUtxoQuery era (ReaderT e m)
-instance MonadUtxoQuery era m => MonadUtxoQuery era (StrictState.StateT s m)
-instance MonadUtxoQuery era m => MonadUtxoQuery era (LazyState.StateT s m)
-instance MonadUtxoQuery era m => MonadUtxoQuery era (MonadBlockchainCardanoNodeT era m)
-instance MonadUtxoQuery era m => MonadUtxoQuery era (MonadLogIgnoreT m)
-instance MonadUtxoQuery era m => MonadUtxoQuery era (PropertyM m)
+instance MonadUtxoQuery m => MonadUtxoQuery (ResultT m) where
+instance MonadUtxoQuery m => MonadUtxoQuery (ExceptT e m)
+instance MonadUtxoQuery m => MonadUtxoQuery (ReaderT e m)
+instance MonadUtxoQuery m => MonadUtxoQuery (StrictState.StateT s m)
+instance MonadUtxoQuery m => MonadUtxoQuery (LazyState.StateT s m)
+instance MonadUtxoQuery m => MonadUtxoQuery (MonadBlockchainCardanoNodeT era m)
+instance MonadUtxoQuery m => MonadUtxoQuery (MonadLogIgnoreT m)
+instance MonadUtxoQuery m => MonadUtxoQuery (PropertyM m)
 
 -- | Given a single payment credential, find the UTxOs with that credential
-utxosByPaymentCredential :: MonadUtxoQuery era m => PaymentCredential -> m (UtxoSet C.CtxUTxO era (Maybe C.HashableScriptData))
+utxosByPaymentCredential :: MonadUtxoQuery m => PaymentCredential -> m (UtxoSet C.CtxUTxO (Maybe C.HashableScriptData))
 utxosByPaymentCredential = utxosByPaymentCredentials . Set.singleton
 
 {- Note [MonadDatumQuery design]

--- a/src/base/lib/Convex/Class.hs
+++ b/src/base/lib/Convex/Class.hs
@@ -1,13 +1,19 @@
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns         #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE DefaultSignatures      #-}
+{-# LANGUAGE DeriveAnyClass         #-}
+{-# LANGUAGE DerivingStrategies     #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE LambdaCase             #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeOperators          #-}
+{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE ViewPatterns           #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE DerivingVia            #-}
 {-| Typeclasses for blockchain operations
 -}
 module Convex.Class(
@@ -15,12 +21,10 @@ module Convex.Class(
   -- * Monad blockchain
   MonadBlockchain(..),
   trySendTx,
-  SendTxFailed(..),
   singleUTxO,
 
   -- * Monad mockchain
   MonadMockchain(..),
-  MonadBlockchainError(..),
 
   -- * Mockchain state & lenses
   MockChainState (..),
@@ -35,6 +39,7 @@ module Convex.Class(
   -- * Other types
   ExUnitsError(..),
   ValidationError(..),
+  BlockchainException(..),
   _VExUnits,
   _PredicateFailures,
   _ApplyTxFailure,
@@ -66,6 +71,18 @@ module Convex.Class(
   runMonadBlockchainCardanoNodeT
 ) where
 
+import qualified Cardano.Api                                       as C
+import           Cardano.Api.Shelley                               (EraHistory (..),
+                                                                    Hash,
+                                                                    HashableScriptData,
+                                                                    LedgerProtocolParameters (..),
+                                                                    LocalNodeConnectInfo,
+                                                                    NetworkId,
+                                                                    PaymentCredential,
+                                                                    PoolId,
+                                                                    ScriptData,
+                                                                    SlotNo, Tx,
+                                                                    TxId)
 import qualified Cardano.Api.Shelley                               as C
 import           Cardano.Ledger.Alonzo.Plutus.Evaluate             (CollectError)
 import qualified Cardano.Ledger.Core                               as Core
@@ -87,16 +104,16 @@ import           Cardano.Ledger.UMap                               (RDPair (..),
                                                                     compactCoinOrError)
 import           Cardano.Slotting.Time                             (SlotLength,
                                                                     SystemStart)
+import           Control.Exception                                 (Exception,
+                                                                    throwIO)
 import           Control.Lens                                      (_1, set, to,
                                                                     view, (^.))
 import           Control.Lens.TH                                   (makeLensesFor,
                                                                     makePrisms)
 import           Control.Monad.Except                              (MonadError,
-                                                                    catchError,
-                                                                    runExceptT,
-                                                                    throwError)
+                                                                    runExceptT)
 import           Control.Monad.IO.Class                            (MonadIO (..))
-import           Control.Monad.Primitive                           (PrimMonad (..))
+import           Control.Monad.Primitive                           (PrimMonad)
 import           Control.Monad.Reader                              (MonadTrans,
                                                                     ReaderT (..),
                                                                     ask, asks,
@@ -106,19 +123,14 @@ import qualified Control.Monad.State.Strict                        as StrictStat
 import           Control.Monad.Trans.Except                        (ExceptT (..))
 import           Control.Monad.Trans.Except.Result                 (ResultT)
 import qualified Convex.CardanoApi.Lenses                          as L
-import           Convex.Constants                                  (ERA)
 import           Convex.MonadLog                                   (MonadLog (..),
                                                                     MonadLogIgnoreT (..),
-                                                                    logInfoS,
-                                                                    logWarn,
-                                                                    logWarnS)
+                                                                    MonadLogKatipT (..))
 import           Convex.NodeParams                                 (NodeParams,
                                                                     pParams)
 import           Convex.Utils                                      (posixTimeToSlotUnsafe,
                                                                     slotToUtcTime)
 import           Convex.Utxos                                      (UtxoSet)
-import           Data.Aeson                                        (FromJSON,
-                                                                    ToJSON)
 import           Data.Bifunctor                                    (Bifunctor (..))
 import           Data.Functor                                      ((<&>))
 import           Data.Map                                          (Map)
@@ -126,25 +138,47 @@ import qualified Data.Map                                          as Map
 import           Data.Set                                          (Set)
 import qualified Data.Set                                          as Set
 import           Data.Time.Clock                                   (UTCTime)
-import           GHC.Generics                                      (Generic)
+import           Katip.Monadic                                     (KatipContextT (..))
 import           Ouroboros.Consensus.HardFork.History              (interpretQuery,
                                                                     slotToSlotLength)
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type   as T
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))
 import qualified PlutusLedgerApi.V1                                as PV1
-import           Prettyprinter                                     (Pretty (..),
-                                                                    (<+>))
 import           Test.QuickCheck.Monadic                           (PropertyM)
+
+-- Error types
+data ExUnitsError era =
+  Phase1Error (C.TransactionValidityError era)
+  | Phase2Error C.ScriptExecutionError
+  deriving stock Show
+  deriving anyclass Exception
+
+makePrisms ''ExUnitsError
+
+data ValidationError era =
+  ValidationErrorInMode !C.TxValidationErrorInCardanoMode
+  | VExUnits !(ExUnitsError era)
+  | PredicateFailures ![CollectError (C.ShelleyLedgerEra era)]
+  | ApplyTxFailure !(ApplyTxError (C.ShelleyLedgerEra era))
+  deriving anyclass Exception
+
+instance C.IsAlonzoBasedEra era => Show (ValidationError era) where
+  show err = C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $ "ValidationError: " <> case err of
+    ValidationErrorInMode err' -> "ValidationErrorInMode: " <> show err'
+    VExUnits err'              -> "VExUnits: " <> show err'
+    PredicateFailures errs'    -> "PredicateFailures: " <> show errs'
+    ApplyTxFailure err'        -> "ApplyTxFailure: " <> show err'
+
+makePrisms ''ValidationError
 
 {-| Send transactions and resolve tx inputs.
 -}
-class Monad m => MonadBlockchain m where
-  -- see note Note [sendTx Failure]
-  sendTx                  :: C.Tx C.ConwayEra -> m (Either SendTxFailed C.TxId) -- ^ Submit a transaction to the network
-  utxoByTxIn              :: Set C.TxIn -> m (C.UTxO C.ConwayEra) -- ^ Resolve tx inputs
-  queryProtocolParameters :: m (C.LedgerProtocolParameters C.ConwayEra) -- ^ Get the protocol parameters
-  queryStakeAddresses     :: Set C.StakeCredential -> C.NetworkId -> m (Map C.StakeAddress C.Quantity, Map C.StakeAddress C.PoolId) -- ^ Get stake rewards
-  queryStakePools         :: m (Set C.PoolId) -- ^ Get the stake pools
+class Monad m => MonadBlockchain era m | m -> era where
+  sendTx                  :: Tx era -> m (Either (ValidationError era) TxId) -- ^ Submit a transaction to the network
+  utxoByTxIn              :: Set C.TxIn -> m (C.UTxO era) -- ^ Resolve tx inputs
+  queryProtocolParameters :: m (LedgerProtocolParameters era) -- ^ Get the protocol parameters
+  queryStakeAddresses     :: Set C.StakeCredential -> NetworkId -> m (Map C.StakeAddress C.Quantity, Map C.StakeAddress PoolId) -- ^ Get stake rewards
+  queryStakePools         :: m (Set PoolId) -- ^ Get the stake pools
   querySystemStart        :: m SystemStart
   queryEraHistory         :: m C.EraHistory
   querySlotNo             :: m (C.SlotNo, SlotLength, UTCTime)
@@ -152,115 +186,62 @@ class Monad m => MonadBlockchain m where
                           -- Slot 0 is returned when at genesis.
   queryNetworkId          :: m C.NetworkId -- ^ Get the network id
 
-{-| Try sending the transaction to the node, failing with 'error' if 'sendTx'
-  was not successful.
--}
-trySendTx :: MonadBlockchain m => C.Tx C.ConwayEra -> m C.TxId
+  default sendTx :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => Tx era -> m (Either (ValidationError era) TxId)
+  sendTx = lift . sendTx
+
+  default utxoByTxIn :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => Set C.TxIn -> m (C.UTxO era)
+  utxoByTxIn = lift . utxoByTxIn
+
+  default queryProtocolParameters :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => m (LedgerProtocolParameters era)
+  queryProtocolParameters = lift queryProtocolParameters
+
+  default queryStakeAddresses :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => Set C.StakeCredential -> NetworkId -> m (Map C.StakeAddress C.Quantity, Map C.StakeAddress PoolId) -- ^ Get stake rewards
+  queryStakeAddresses = (lift .) . queryStakeAddresses
+
+  default queryStakePools :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => m (Set PoolId)
+  queryStakePools = lift queryStakePools
+
+  default querySystemStart :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => m SystemStart
+  querySystemStart = lift querySystemStart
+
+  default queryEraHistory :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => m EraHistory
+  queryEraHistory = lift queryEraHistory
+
+  default querySlotNo :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => m (SlotNo, SlotLength, UTCTime)
+  querySlotNo = lift querySlotNo
+
+  default queryNetworkId :: (MonadTrans t, m ~ t n, MonadBlockchain era n) => m NetworkId
+  queryNetworkId = lift queryNetworkId
+
+
+trySendTx :: (MonadBlockchain era m, C.IsAlonzoBasedEra era) => Tx era -> m TxId
 trySendTx = fmap (either (error . show) id) . sendTx
 
-deriving newtype instance MonadBlockchain m => MonadBlockchain (MonadLogIgnoreT m)
+deriving newtype instance MonadBlockchain era m => MonadBlockchain era (KatipContextT m)
+deriving newtype instance MonadBlockchain era m => MonadBlockchain era (MonadLogKatipT m)
+deriving newtype instance MonadBlockchain era m => MonadBlockchain era (MonadLogIgnoreT m)
 
-instance MonadBlockchain m => MonadBlockchain (ResultT m) where
-  sendTx = lift . sendTx
-  utxoByTxIn = lift . utxoByTxIn
-  queryProtocolParameters = lift queryProtocolParameters
-  queryStakeAddresses creds = lift . queryStakeAddresses creds
-  queryStakePools = lift queryStakePools
-  querySystemStart = lift querySystemStart
-  queryEraHistory = lift queryEraHistory
-  querySlotNo = lift querySlotNo
-  queryNetworkId = lift queryNetworkId
-
-instance MonadBlockchain m => MonadBlockchain (ExceptT e m) where
-  sendTx = lift . sendTx
-  utxoByTxIn = lift . utxoByTxIn
-  queryProtocolParameters = lift queryProtocolParameters
-  queryStakeAddresses creds = lift . queryStakeAddresses creds
-  queryStakePools = lift queryStakePools
-  querySystemStart = lift querySystemStart
-  queryEraHistory = lift queryEraHistory
-  querySlotNo = lift querySlotNo
-  queryNetworkId = lift queryNetworkId
-
-instance MonadBlockchain m => MonadBlockchain (ReaderT e m) where
-  sendTx = lift . sendTx
-  utxoByTxIn = lift . utxoByTxIn
-  queryProtocolParameters = lift queryProtocolParameters
-  queryStakeAddresses creds = lift . queryStakeAddresses creds
-  queryStakePools = lift queryStakePools
-  querySystemStart = lift querySystemStart
-  queryEraHistory = lift queryEraHistory
-  querySlotNo = lift querySlotNo
-  queryNetworkId = lift queryNetworkId
-
-instance MonadBlockchain m => MonadBlockchain (StrictState.StateT e m) where
-  sendTx = lift . sendTx
-  utxoByTxIn = lift . utxoByTxIn
-  queryProtocolParameters = lift queryProtocolParameters
-  queryStakeAddresses creds = lift . queryStakeAddresses creds
-  queryStakePools = lift queryStakePools
-  querySystemStart = lift querySystemStart
-  queryEraHistory = lift queryEraHistory
-  querySlotNo = lift querySlotNo
-  queryNetworkId = lift queryNetworkId
-
-instance MonadBlockchain m => MonadBlockchain (LazyState.StateT e m) where
-  sendTx = lift . sendTx
-  utxoByTxIn = lift . utxoByTxIn
-  queryProtocolParameters = lift queryProtocolParameters
-  queryStakeAddresses creds = lift . queryStakeAddresses creds
-  queryStakePools = lift queryStakePools
-  querySystemStart = lift querySystemStart
-  queryEraHistory = lift queryEraHistory
-  querySlotNo = lift querySlotNo
-  queryNetworkId = lift queryNetworkId
+instance MonadBlockchain era m => MonadBlockchain era (ResultT m)
+instance MonadBlockchain era m => MonadBlockchain era (ExceptT e m)
+instance MonadBlockchain era m => MonadBlockchain era (ReaderT e m)
+instance MonadBlockchain era m => MonadBlockchain era (StrictState.StateT e m)
+instance MonadBlockchain era m => MonadBlockchain era (LazyState.StateT e m)
 
 -- | Look up  a single UTxO
-singleUTxO :: MonadBlockchain m => C.TxIn -> m (Maybe (C.TxOut C.CtxUTxO C.ConwayEra))
+singleUTxO :: MonadBlockchain era m => C.TxIn -> m (Maybe (C.TxOut C.CtxUTxO era))
 singleUTxO txi =  utxoByTxIn (Set.singleton txi) >>= \case
   C.UTxO (Map.toList -> [(_, o)]) -> pure (Just o)
   _ -> pure Nothing
 
-
-{- Note [sendTx Failure]
-
-It would be nice to return a more accurate error type than 'SendTxFailed',
-but our two implementations of 'MonadBlockchain' (mockchain and cardano-node backend)
-have different errors and it does not seem possible to find a common type.
-
--}
-
--- | Error message obtained when a transaction was not accepted by the node.
---
-newtype SendTxFailed = SendTxFailed { unSendTxFailed :: String }
-  deriving stock (Eq, Ord, Show)
-
-instance Pretty SendTxFailed where
-  pretty (SendTxFailed msg) = "sendTx: Submission failed:" <+> pretty msg
-
-data ExUnitsError =
-  Phase1Error (C.TransactionValidityError C.ConwayEra)
-  | Phase2Error C.ScriptExecutionError
-  deriving (Show)
-
-makePrisms ''ExUnitsError
-
-data ValidationError =
-  VExUnits ExUnitsError
-  | PredicateFailures [CollectError ERA]
-  | ApplyTxFailure (ApplyTxError ERA)
-  deriving (Show)
-
-makePrisms ''ValidationError
 {-| State of the mockchain
 -}
-data MockChainState =
+data MockChainState era =
   MockChainState
-    { mcsEnv                :: MempoolEnv ERA
-    , mcsPoolState          :: MempoolState ERA
-    , mcsTransactions       :: [(Validated (Core.Tx ERA), [PlutusWithContext StandardCrypto])] -- ^ Transactions that were submitted to the mockchain and validated
-    , mcsFailedTransactions :: [(C.Tx C.ConwayEra, ValidationError)] -- ^ Transactions that were submitted to the mockchain, but failed with a validation error
-    , mcsDatums             :: Map (C.Hash C.ScriptData) C.HashableScriptData
+    { mcsEnv                :: MempoolEnv (C.ShelleyLedgerEra era)
+    , mcsPoolState          :: MempoolState (C.ShelleyLedgerEra era)
+    , mcsTransactions       :: [(Validated (Core.Tx (C.ShelleyLedgerEra era)), [PlutusWithContext StandardCrypto])] -- ^ Transactions that were submitted to the mockchain and validated
+    , mcsFailedTransactions :: [(Tx era, ValidationError era)] -- ^ Transactions that were submitted to the mockchain, but failed with a validation error
+    , mcsDatums             :: Map (Hash ScriptData) HashableScriptData
     }
 
 makeLensesFor
@@ -273,39 +254,31 @@ makeLensesFor
 
 {-| Modify the mockchain internals
 -}
-class MonadBlockchain m => MonadMockchain m where
-  modifyMockChainState :: (MockChainState -> (MockChainState, a)) -> m a
-  askNodeParams :: m NodeParams
+class MonadBlockchain era m => MonadMockchain era m where
+  modifyMockChainState :: (MockChainState era -> (a, MockChainState era)) -> m a
+  askNodeParams :: m (NodeParams era)
 
-deriving newtype instance MonadMockchain m => MonadMockchain (MonadLogIgnoreT m)
-
-instance MonadMockchain m => MonadMockchain (ResultT m) where
+  default modifyMockChainState :: (MonadTrans t, m ~ t n, MonadMockchain era n) => (MockChainState era -> (a, MockChainState era)) -> m a
   modifyMockChainState = lift . modifyMockChainState
+
+  default askNodeParams :: (MonadTrans t, m ~ t n, MonadMockchain era n) => m (NodeParams era)
   askNodeParams = lift askNodeParams
 
-instance MonadMockchain m => MonadMockchain (ReaderT e m) where
-  modifyMockChainState = lift . modifyMockChainState
-  askNodeParams = lift askNodeParams
+deriving newtype instance MonadMockchain era m => MonadMockchain era (MonadLogIgnoreT m)
 
-instance MonadMockchain m => MonadMockchain (ExceptT e m) where
-  modifyMockChainState = lift . modifyMockChainState
-  askNodeParams = lift askNodeParams
+instance MonadMockchain era m => MonadMockchain era (ResultT m)
+instance MonadMockchain era m => MonadMockchain era (ReaderT e m)
+instance MonadMockchain era m => MonadMockchain era (ExceptT e m)
+instance MonadMockchain era m => MonadMockchain era (StrictState.StateT e m)
+instance MonadMockchain era m => MonadMockchain era (LazyState.StateT e m)
 
-instance MonadMockchain m => MonadMockchain (StrictState.StateT e m) where
-  modifyMockChainState = lift . modifyMockChainState
-  askNodeParams = lift askNodeParams
-
-instance MonadMockchain m => MonadMockchain (LazyState.StateT e m) where
-  modifyMockChainState = lift . modifyMockChainState
-  askNodeParams = lift askNodeParams
-
-getMockChainState :: MonadMockchain m => m MockChainState
+getMockChainState :: MonadMockchain era m => m (MockChainState era)
 getMockChainState = modifyMockChainState (\s -> (s, s))
 
-putMockChainState :: MonadMockchain m => MockChainState -> m ()
-putMockChainState s = modifyMockChainState (const (s, ()))
+putMockChainState :: MonadMockchain era m => MockChainState era -> m ()
+putMockChainState s = modifyMockChainState (const ((), s))
 
-setReward :: MonadMockchain m => C.StakeCredential -> Coin -> m ()
+setReward :: forall era m. (Core.EraCrypto (C.ShelleyLedgerEra era) ~ StandardCrypto, MonadMockchain era m) => C.StakeCredential -> Coin -> m ()
 setReward cred coin = do
   mcs <- getMockChainState
   let
@@ -317,50 +290,53 @@ setReward cred coin = do
         (rewards dState)
   putMockChainState (set (poolState . lsCertStateL . certDStateL . dsUnifiedL) umap mcs)
 
-modifySlot :: MonadMockchain m => (C.SlotNo -> (C.SlotNo, a)) -> m a
+modifySlot :: MonadMockchain era m => (SlotNo -> (SlotNo, a)) -> m a
 modifySlot f = modifyMockChainState $ \s ->
   let (s', a) = f (s ^. env . L.slot)
-  in (set (env . L.slot) s' s, a)
+  in (a, set (env . L.slot) s' s)
 
 {-| Get the current slot number
 -}
-getSlot :: MonadMockchain m => m C.SlotNo
+getSlot :: MonadMockchain era m => m SlotNo
 getSlot = modifySlot (\s -> (s, s))
 
 {-| Get the current slot number
 -}
-setSlot :: MonadMockchain m => C.SlotNo -> m ()
+setSlot :: MonadMockchain era m => SlotNo -> m ()
 setSlot s = modifySlot (\_ -> (s, ()))
 
-modifyUtxo :: MonadMockchain m => (UTxO ERA -> (UTxO ERA, a)) -> m a
-modifyUtxo f = askNodeParams >>= \np -> modifyMockChainState $ \s ->
+modifyUtxo :: forall era m a.
+  (C.IsShelleyBasedEra era, MonadMockchain era m)
+  => (UTxO (C.ShelleyLedgerEra era) -> (UTxO (C.ShelleyLedgerEra era), a)) -> m a
+modifyUtxo f = C.shelleyBasedEraConstraints @era C.shelleyBasedEra $
+  askNodeParams >>= \np -> modifyMockChainState $ \s ->
   let (u', a) = f (s ^. poolState . L.utxoState . L._UTxOState (pParams np) . _1)
-  in (set (poolState . L.utxoState . L._UTxOState (pParams np) . _1) u' s, a)
+  in (a, set (poolState . L.utxoState . L._UTxOState (pParams np) . _1) u' s)
 
 {-| Get the UTxO set |-}
-getUtxo :: MonadMockchain m => m (UTxO ERA)
+getUtxo :: (MonadMockchain era m, C.IsShelleyBasedEra era) => m (UTxO (C.ShelleyLedgerEra era))
 getUtxo = modifyUtxo (\s -> (s, s))
 
 {-| Set the UTxO set |-}
-setUtxo :: MonadMockchain m => UTxO ERA -> m ()
+setUtxo :: (MonadMockchain era m, C.IsShelleyBasedEra era) => UTxO (C.ShelleyLedgerEra era) -> m ()
 setUtxo u = modifyUtxo (const (u, ()))
 
 {-| Return all Tx's from the ledger state -}
-getTxs :: MonadMockchain m => m [C.Tx C.ConwayEra]
-getTxs = getMockChainState <&> view (transactions . traverse . _1 . to ((: []) . C.ShelleyTx C.ShelleyBasedEraConway . extractTx))
+getTxs :: (MonadMockchain era m, C.IsShelleyBasedEra era) => m [C.Tx era]
+getTxs = getMockChainState <&> view (transactions . traverse . _1 . to ((: []) . C.ShelleyTx C.shelleyBasedEra . extractTx))
 
 {-| Return all Tx's from the ledger state -}
 
 {-| Set the slot number to the slot that contains the given POSIX time.
 -}
-setPOSIXTime :: (MonadFail m, MonadMockchain m) => PV1.POSIXTime -> m ()
+setPOSIXTime :: (MonadFail m, MonadMockchain era m) => PV1.POSIXTime -> m ()
 setPOSIXTime tm =
   (posixTimeToSlotUnsafe <$> queryEraHistory <*> querySystemStart <*> pure tm) >>= either fail (setSlot . view _1)
 
 {-| Change the clock so that the current slot time is within the given validity range.
 This MAY move the clock backwards!
 -}
-setTimeToValidRange :: MonadMockchain m => (C.TxValidityLowerBound C.ConwayEra, C.TxValidityUpperBound C.ConwayEra) -> m ()
+setTimeToValidRange :: MonadMockchain era m => (C.TxValidityLowerBound era, C.TxValidityUpperBound era) -> m ()
 setTimeToValidRange = \case
   (C.TxValidityLowerBound _ lowerSlot, _)        -> setSlot lowerSlot
   (_, C.TxValidityUpperBound _ (Just upperSlot)) -> setSlot (pred upperSlot)
@@ -368,14 +344,8 @@ setTimeToValidRange = \case
 
 {-| Increase the slot number by 1.
 -}
-nextSlot :: MonadMockchain m => m ()
+nextSlot :: MonadMockchain era m => m ()
 nextSlot = modifySlot (\s -> (succ s, ()))
-
-data MonadBlockchainError e =
-  MonadBlockchainError e
-  | FailWith String
-  deriving stock (Functor, Generic, Show)
-  deriving anyclass (ToJSON, FromJSON)
 
 {- Note [MonadUtxoQuery design]
 
@@ -392,40 +362,28 @@ control over the capabilities they require.
 -- | A capability typeclass that provides methods for querying a chain indexer.
 --   See note [MonadUtxoQuery design].
 --   NOTE: There are currently no implementations of this class in sc-tools.
-class Monad m => MonadUtxoQuery m where
+class Monad m => MonadUtxoQuery era m | m -> era where
   -- | Given a set of payment credentials, retrieve all UTxOs associated with
   -- those payment credentials according to the current indexed blockchain
   -- state. Each UTXO also possibly has the resolved datum (meaning that if we
   -- only have the datum hash, the implementation should try and resolve it to
   -- the actual datum).
-  utxosByPaymentCredentials :: Set C.PaymentCredential -> m (UtxoSet C.CtxUTxO (Maybe C.HashableScriptData))
+  utxosByPaymentCredentials :: Set PaymentCredential -> m (UtxoSet C.CtxUTxO era (Maybe C.HashableScriptData))
 
-instance MonadUtxoQuery m => MonadUtxoQuery (ResultT m) where
+  default utxosByPaymentCredentials :: (MonadTrans t, m ~ t n, MonadUtxoQuery era n) => Set PaymentCredential -> m (UtxoSet C.CtxUTxO era (Maybe C.HashableScriptData))
   utxosByPaymentCredentials = lift . utxosByPaymentCredentials
 
-instance MonadUtxoQuery m => MonadUtxoQuery (ExceptT e m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
-
-instance MonadUtxoQuery m => MonadUtxoQuery (ReaderT e m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
-
-instance MonadUtxoQuery m => MonadUtxoQuery (StrictState.StateT s m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
-
-instance MonadUtxoQuery m => MonadUtxoQuery (LazyState.StateT s m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
-
-instance MonadUtxoQuery m => MonadUtxoQuery (MonadBlockchainCardanoNodeT e m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
-
-instance MonadUtxoQuery m => MonadUtxoQuery (MonadLogIgnoreT m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
-
-instance MonadUtxoQuery m => MonadUtxoQuery (PropertyM m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
+instance MonadUtxoQuery era m => MonadUtxoQuery era (ResultT m) where
+instance MonadUtxoQuery era m => MonadUtxoQuery era (ExceptT e m)
+instance MonadUtxoQuery era m => MonadUtxoQuery era (ReaderT e m)
+instance MonadUtxoQuery era m => MonadUtxoQuery era (StrictState.StateT s m)
+instance MonadUtxoQuery era m => MonadUtxoQuery era (LazyState.StateT s m)
+instance MonadUtxoQuery era m => MonadUtxoQuery era (MonadBlockchainCardanoNodeT era m)
+instance MonadUtxoQuery era m => MonadUtxoQuery era (MonadLogIgnoreT m)
+instance MonadUtxoQuery era m => MonadUtxoQuery era (PropertyM m)
 
 -- | Given a single payment credential, find the UTxOs with that credential
-utxosByPaymentCredential :: MonadUtxoQuery m => C.PaymentCredential -> m (UtxoSet C.CtxUTxO (Maybe C.HashableScriptData))
+utxosByPaymentCredential :: MonadUtxoQuery era m => PaymentCredential -> m (UtxoSet C.CtxUTxO era (Maybe C.HashableScriptData))
 utxosByPaymentCredential = utxosByPaymentCredentials . Set.singleton
 
 {- Note [MonadDatumQuery design]
@@ -452,7 +410,7 @@ instance MonadDatumQuery m => MonadDatumQuery (StrictState.StateT s m) where
 instance MonadDatumQuery m => MonadDatumQuery (LazyState.StateT s m) where
   queryDatumFromHash = lift . queryDatumFromHash
 
-instance MonadDatumQuery m => MonadDatumQuery (MonadBlockchainCardanoNodeT e m) where
+instance MonadDatumQuery m => MonadDatumQuery (MonadBlockchainCardanoNodeT era m) where
   queryDatumFromHash = lift . queryDatumFromHash
 
 instance MonadDatumQuery m => MonadDatumQuery (MonadLogIgnoreT m) where
@@ -464,66 +422,56 @@ instance MonadDatumQuery m => MonadDatumQuery (PropertyM m) where
 
 {-| 'MonadBlockchain' implementation that connects to a cardano node
 -}
-newtype MonadBlockchainCardanoNodeT e m a = MonadBlockchainCardanoNodeT { unMonadBlockchainCardanoNodeT :: ReaderT C.LocalNodeConnectInfo (ExceptT (MonadBlockchainError e) m) a }
-  deriving newtype (Functor, Applicative, Monad, MonadIO)
+newtype BlockchainException = BlockchainException String
+  deriving stock Show
+  deriving anyclass Exception
 
-instance Monad m => MonadError e (MonadBlockchainCardanoNodeT e m) where
-  throwError = MonadBlockchainCardanoNodeT . throwError . MonadBlockchainError
-  catchError (MonadBlockchainCardanoNodeT action) handler = MonadBlockchainCardanoNodeT $ catchError action (\case { MonadBlockchainError e -> unMonadBlockchainCardanoNodeT (handler e); e' -> throwError e' })
+newtype MonadBlockchainCardanoNodeT era m a = MonadBlockchainCardanoNodeT { unMonadBlockchainCardanoNodeT :: ReaderT LocalNodeConnectInfo m a }
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadError e, MonadFail, PrimMonad)
 
-instance PrimMonad m => PrimMonad (MonadBlockchainCardanoNodeT e m) where
-  type PrimState (MonadBlockchainCardanoNodeT e m) = PrimState m
-  {-# INLINEABLE primitive #-}
-  primitive f = lift (primitive f)
+runMonadBlockchainCardanoNodeT :: LocalNodeConnectInfo -> MonadBlockchainCardanoNodeT era m a -> m a
+runMonadBlockchainCardanoNodeT info (MonadBlockchainCardanoNodeT action) = runReaderT action info
 
-runMonadBlockchainCardanoNodeT :: C.LocalNodeConnectInfo -> MonadBlockchainCardanoNodeT e m a -> m (Either (MonadBlockchainError e) a)
-runMonadBlockchainCardanoNodeT info (MonadBlockchainCardanoNodeT action) = runExceptT (runReaderT action info)
-
-runQuery :: (MonadIO m, MonadLog m) => C.QueryInMode a -> MonadBlockchainCardanoNodeT e m a
+runQuery :: MonadIO m => C.QueryInMode a -> MonadBlockchainCardanoNodeT era m a
 runQuery qry = MonadBlockchainCardanoNodeT $ do
   info <- ask
   result <- liftIO (runExceptT $ C.queryNodeLocalState info T.VolatileTip qry)
   case result of
     Left err -> do
       let msg = "runQuery: Query failed: " <> show err
-      logWarnS msg
-      throwError $ FailWith msg
+      liftIO $ throwIO $ BlockchainException msg
     Right result' -> do
       pure result'
 
-runQuery' :: (MonadIO m, MonadLog m, Show e1) => C.QueryInMode (Either e1 a) -> MonadBlockchainCardanoNodeT e2 m a
+runQuery' :: (MonadIO m, Show e1) => C.QueryInMode (Either e1 a) -> MonadBlockchainCardanoNodeT era m a
 runQuery' qry = runQuery qry >>= \case
   Left err -> MonadBlockchainCardanoNodeT $ do
     let msg = "runQuery': Era mismatch: " <> show err
-    logWarnS msg
-    throwError $ FailWith msg
+    liftIO $ throwIO $ BlockchainException msg
   Right result' -> pure result'
 
-instance (MonadLog m, MonadIO m) => MonadBlockchain (MonadBlockchainCardanoNodeT e m) where
+instance (MonadIO m, C.IsShelleyBasedEra era) => MonadBlockchain era (MonadBlockchainCardanoNodeT era m) where
   sendTx tx = MonadBlockchainCardanoNodeT $ do
     let txId = C.getTxId (C.getTxBody tx)
     info <- ask
-    result <- liftIO (C.submitTxToNodeLocal info (C.TxInMode C.ShelleyBasedEraConway tx))
-    case result of
-      SubmitSuccess -> do
-        logInfoS ("sendTx: Submitted " <> show txId)
-        pure (Right txId)
-      SubmitFail reason -> do
-        let msg = SendTxFailed (show reason)
-        logWarn msg
-        pure (Left msg)
+    result <- liftIO (C.submitTxToNodeLocal info (C.TxInMode C.shelleyBasedEra tx))
+    pure $ case result of
+      SubmitSuccess ->
+        Right txId
+      SubmitFail reason ->
+        Left $ ValidationErrorInMode reason
 
   utxoByTxIn txIns =
-    runQuery' (C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraConway (C.QueryUTxO (C.QueryUTxOByTxIn txIns))))
+    runQuery' (C.QueryInEra (C.QueryInShelleyBasedEra C.shelleyBasedEra (C.QueryUTxO (C.QueryUTxOByTxIn txIns))))
 
   queryProtocolParameters = do
-    C.LedgerProtocolParameters <$> runQuery' (C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraConway C.QueryProtocolParameters))
+    LedgerProtocolParameters <$> runQuery' (C.QueryInEra (C.QueryInShelleyBasedEra C.shelleyBasedEra C.QueryProtocolParameters))
 
   queryStakeAddresses creds nid =
-    first (fmap C.lovelaceToQuantity) <$> runQuery' (C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraConway (C.QueryStakeAddresses creds nid)))
+    first (fmap C.lovelaceToQuantity) <$> runQuery' (C.QueryInEra (C.QueryInShelleyBasedEra (C.shelleyBasedEra @era) (C.QueryStakeAddresses creds nid)))
 
   queryStakePools =
-    runQuery' (C.QueryInEra (C.QueryInShelleyBasedEra C.ShelleyBasedEraConway C.QueryStakePools))
+    runQuery' (C.QueryInEra (C.QueryInShelleyBasedEra (C.shelleyBasedEra @era) C.QueryStakePools))
 
   querySystemStart = runQuery C.QuerySystemStart
 
@@ -537,20 +485,13 @@ instance (MonadLog m, MonadIO m) => MonadBlockchain (MonadBlockchainCardanoNodeT
     MonadBlockchainCardanoNodeT $ do
       let logErr err = do
             let msg = "querySlotNo: Failed with " <> err
-            logWarnS msg
-            throwError $ FailWith msg
+            liftIO $ throwIO $ BlockchainException msg
       utctime <- either logErr pure (slotToUtcTime eraHistory systemStart slotNo)
       either (logErr . show) (\l -> pure (slotNo, l, utctime)) (interpretQuery interpreter $ slotToSlotLength slotNo)
 
   queryNetworkId = MonadBlockchainCardanoNodeT (asks C.localNodeNetworkId)
 
-instance MonadTrans (MonadBlockchainCardanoNodeT e) where
-  lift = MonadBlockchainCardanoNodeT . lift .lift
+instance MonadTrans (MonadBlockchainCardanoNodeT era) where
+  lift = MonadBlockchainCardanoNodeT . lift
 
-instance (MonadLog m) => MonadLog (MonadBlockchainCardanoNodeT e m) where
-  logInfo' = lift . logInfo'
-  logWarn' = lift . logWarn'
-  logDebug' = lift . logDebug'
-
-instance (MonadLog m) => MonadFail (MonadBlockchainCardanoNodeT e m) where
-  fail = MonadBlockchainCardanoNodeT . throwError . FailWith
+instance (MonadLog m) => MonadLog (MonadBlockchainCardanoNodeT era m)

--- a/src/base/lib/Convex/Class.hs
+++ b/src/base/lib/Convex/Class.hs
@@ -226,6 +226,7 @@ instance MonadBlockchain era m => MonadBlockchain era (ExceptT e m)
 instance MonadBlockchain era m => MonadBlockchain era (ReaderT e m)
 instance MonadBlockchain era m => MonadBlockchain era (StrictState.StateT e m)
 instance MonadBlockchain era m => MonadBlockchain era (LazyState.StateT e m)
+instance MonadBlockchain era m => MonadBlockchain era (PropertyM m)
 
 -- | Look up  a single UTxO
 singleUTxO :: MonadBlockchain era m => C.TxIn -> m (Maybe (C.TxOut C.CtxUTxO era))
@@ -271,6 +272,7 @@ instance MonadMockchain era m => MonadMockchain era (ReaderT e m)
 instance MonadMockchain era m => MonadMockchain era (ExceptT e m)
 instance MonadMockchain era m => MonadMockchain era (StrictState.StateT e m)
 instance MonadMockchain era m => MonadMockchain era (LazyState.StateT e m)
+instance MonadMockchain era m => MonadMockchain era (PropertyM m)
 
 getMockChainState :: MonadMockchain era m => m (MockChainState era)
 getMockChainState = modifyMockChainState (\s -> (s, s))
@@ -303,7 +305,7 @@ getSlot = modifySlot (\s -> (s, s))
 {-| Get the current slot number
 -}
 setSlot :: MonadMockchain era m => SlotNo -> m ()
-setSlot s = modifySlot (\_ -> (s, ()))
+setSlot s = modifySlot (const (s, ()))
 
 modifyUtxo :: forall era m a.
   (C.IsShelleyBasedEra era, MonadMockchain era m)

--- a/src/base/lib/Convex/MonadLog.hs
+++ b/src/base/lib/Convex/MonadLog.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE DefaultSignatures    #-}
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-| Simple logging
 -}
@@ -57,6 +59,15 @@ class Monad m => MonadLog m where
 
   -- | Log a message at the @debug@ level
   logDebug' :: Doc Void -> m ()
+
+  default logInfo' :: (MonadTrans t, m ~ t n, MonadLog n) => Doc Void -> m ()
+  logInfo' = lift . logInfo'
+
+  default logWarn' :: (MonadTrans t, m ~ t n, MonadLog n) => Doc Void -> m ()
+  logWarn' = lift . logWarn'
+
+  default logDebug' :: (MonadTrans t, m ~ t n, MonadLog n) => Doc Void -> m ()
+  logDebug' = lift . logDebug'
 
 instance MonadLog m => MonadLog (ReaderT e m) where
   logInfo' = lift . logInfo'

--- a/src/base/lib/Convex/NodeParams.hs
+++ b/src/base/lib/Convex/NodeParams.hs
@@ -32,22 +32,21 @@ module Convex.NodeParams(
   L.hkdCostModelsL
 ) where
 
-import           Cardano.Api                      (ConwayEra)
-import           Cardano.Api.Ledger               (PParams)
-import qualified Cardano.Api.Ledger               as L
-import           Cardano.Api.Shelley              (EraHistory,
-                                                   LedgerProtocolParameters (..),
-                                                   NetworkId (..), PoolId)
-import qualified Cardano.Ledger.Alonzo.PParams    as L
-import           Cardano.Slotting.Time            (SlotLength, SystemStart)
-import           Control.Lens.TH                  (makeLensesFor)
-import           Data.Set                         as Set (Set)
-import           Ouroboros.Consensus.Shelley.Eras (StandardConway)
+import           Cardano.Api.Ledger            (PParams)
+import qualified Cardano.Api.Ledger            as L
+import           Cardano.Api.Shelley           (EraHistory,
+                                                LedgerProtocolParameters (..),
+                                                NetworkId (..), PoolId,
+                                                ShelleyLedgerEra)
+import qualified Cardano.Ledger.Alonzo.PParams as L
+import           Cardano.Slotting.Time         (SlotLength, SystemStart)
+import           Control.Lens.TH               (makeLensesFor)
+import           Data.Set                      as Set (Set)
 
-data NodeParams =
+data NodeParams era =
   NodeParams
     { npNetworkId          :: NetworkId
-    , npProtocolParameters :: LedgerProtocolParameters ConwayEra
+    , npProtocolParameters :: LedgerProtocolParameters era
     , npSystemStart        :: SystemStart
     , npEraHistory         :: EraHistory
     , npStakePools         :: Set PoolId
@@ -68,6 +67,6 @@ makeLensesFor
   ] ''LedgerProtocolParameters
 
 -- | Convert `Params` to cardano-ledger `PParams`
-pParams :: NodeParams -> PParams StandardConway
+pParams :: NodeParams era -> PParams (ShelleyLedgerEra era)
 pParams NodeParams { npProtocolParameters } = case npProtocolParameters of
   LedgerProtocolParameters p -> p

--- a/src/base/lib/Convex/PlutusLedger.hs
+++ b/src/base/lib/Convex/PlutusLedger.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE TupleSections    #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-| Translating between cardano-api/cardano-ledger and plutus representations
 -}
 module Convex.PlutusLedger(

--- a/src/base/lib/Convex/PlutusLedger.hs
+++ b/src/base/lib/Convex/PlutusLedger.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE TupleSections    #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-deprecations #-} -- see https://github.com/j-mueller/sc-tools/issues/213
 {-| Translating between cardano-api/cardano-ledger and plutus representations
 -}
 module Convex.PlutusLedger(

--- a/src/base/lib/Convex/Utils.hs
+++ b/src/base/lib/Convex/Utils.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE ViewPatterns      #-}
 {-| Conversion functions and other conveniences
@@ -40,7 +41,12 @@ module Convex.Utils(
   utcTimeToPosixTime,
   posixTimeToSlot,
   posixTimeToSlotUnsafe,
-  toShelleyPaymentCredential
+  toShelleyPaymentCredential,
+  alonzoEraUtxo,
+  inMary,
+  inAlonzo,
+  inBabbage,
+  inConway
 ) where
 
 import           Cardano.Api                              (BlockInMode (..),
@@ -51,6 +57,7 @@ import           Cardano.Api                              (BlockInMode (..),
                                                            PlutusScriptV2,
                                                            SlotNo, Tx, TxIn)
 import qualified Cardano.Api.Shelley                      as C
+import qualified Cardano.Ledger.Alonzo.UTxO               as L
 import qualified Cardano.Ledger.Credential                as Shelley
 import           Cardano.Ledger.Crypto                    (StandardCrypto)
 import           Cardano.Slotting.EpochInfo.API           (epochInfoSlotToUTCTime,
@@ -245,3 +252,43 @@ toShelleyPaymentCredential (PaymentCredentialByKey (C.PaymentKeyHash kh)) =
     Shelley.KeyHashObj kh
 toShelleyPaymentCredential (PaymentCredentialByScript sh) =
     Shelley.ScriptHashObj (C.toShelleyScriptHash sh)
+
+inMary :: forall era a
+  .  C.IsMaryBasedEra era
+  => ((C.IsCardanoEra era, C.IsShelleyBasedEra era, C.IsAllegraBasedEra era) => a)
+  -> a
+inMary f = case C.maryBasedEra @era of
+  C.MaryEraOnwardsMary    -> f
+  C.MaryEraOnwardsAlonzo  -> f
+  C.MaryEraOnwardsBabbage -> f
+  C.MaryEraOnwardsConway  -> f
+
+inAlonzo :: forall era a
+  .  C.IsAlonzoBasedEra era
+  => ((C.IsCardanoEra era, C.IsShelleyBasedEra era, C.IsAllegraBasedEra era, C.IsMaryBasedEra era) => a)
+  -> a
+inAlonzo f = case C.alonzoBasedEra @era of
+  C.AlonzoEraOnwardsAlonzo  -> f
+  C.AlonzoEraOnwardsBabbage -> f
+  C.AlonzoEraOnwardsConway  -> f
+
+inBabbage :: forall era a
+  .  C.IsBabbageBasedEra era
+  => ((C.IsCardanoEra era, C.IsShelleyBasedEra era, C.IsAllegraBasedEra era, C.IsMaryBasedEra era, C.IsAlonzoBasedEra era) => a)
+  -> a
+inBabbage f = case C.babbageBasedEra @era of
+  C.BabbageEraOnwardsBabbage -> f
+  C.BabbageEraOnwardsConway  -> f
+
+inConway :: forall era a
+  .  C.IsConwayBasedEra era
+  => ((C.IsCardanoEra era, C.IsShelleyBasedEra era, C.IsAllegraBasedEra era, C.IsMaryBasedEra era, C.IsAlonzoBasedEra era, C.IsBabbageBasedEra era) => a)
+  -> a
+inConway f = case C.conwayBasedEra @era of
+  C.ConwayEraOnwardsConway -> f
+
+alonzoEraUtxo :: forall era a. C.IsAlonzoBasedEra era => (L.AlonzoEraUTxO (C.ShelleyLedgerEra era) => a) -> a
+alonzoEraUtxo f = case C.alonzoBasedEra @era of
+  C.AlonzoEraOnwardsAlonzo  -> f
+  C.AlonzoEraOnwardsBabbage -> f
+  C.AlonzoEraOnwardsConway  -> f

--- a/src/base/lib/Convex/Utxos.hs
+++ b/src/base/lib/Convex/Utxos.hs
@@ -14,6 +14,8 @@
 
 -- FIXME (koslambrou) Remove once we have the newtype for 'AnyCardanoEra TxOut'.
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# LANGUAGE TypeApplications     #-}
 
 module Convex.Utxos(
   -- * Utxo sets
@@ -33,8 +35,6 @@ module Convex.Utxos(
   removeUtxos,
   fromApiUtxo,
   toApiUtxo,
-  txOutToLatestEra,
-  utxoToLatestEra,
   selectUtxo,
 
   -- * Events based on transactions
@@ -68,8 +68,8 @@ module Convex.Utxos(
   ) where
 
 import           Cardano.Api                   (AddressInEra, BabbageEra,
-                                                Block (..), BlockInMode (..),
-                                                ConwayEra, HashableScriptData,
+                                                Block (..), ConwayEra,
+                                                HashableScriptData,
                                                 PaymentCredential,
                                                 StakeCredential, Tx (..), TxId,
                                                 TxIn (..), TxIx (..), UTxO (..))
@@ -89,14 +89,10 @@ import qualified Cardano.Ledger.TxIn           as CT
 import           Control.Lens                  (_2, makeLenses, makePrisms,
                                                 over, preview, view)
 import qualified Convex.CardanoApi.Lenses      as L
-import           Data.Aeson                    (FromJSON, ToJSON,
-                                                Value (String), object,
-                                                parseJSON, toJSON, withObject,
-                                                (.:), (.=))
+import           Data.Aeson                    (FromJSON, ToJSON)
 import           Data.Bifunctor                (Bifunctor (..))
 import           Data.DList                    (DList)
 import qualified Data.DList                    as DList
-import           Data.Kind                     (Constraint, Type)
 import           Data.Map.Strict               (Map)
 import qualified Data.Map.Strict               as Map
 import           Data.Maybe                    (isJust, isNothing, listToMaybe,
@@ -115,214 +111,67 @@ type AddressCredential = Shelley.PaymentCredential StandardCrypto
 
 {-| A set of unspent transaction outputs
 -}
-newtype UtxoSet ctx a = UtxoSet{ _utxos :: Map C.TxIn (C.InAnyCardanoEra (C.TxOut ctx), a) }
+newtype UtxoSet ctx era a = UtxoSet{ _utxos :: Map C.TxIn (C.TxOut ctx era, a) }
   deriving stock (Functor)
-  deriving newtype (Semigroup, Monoid)
+  deriving newtype (Semigroup, Monoid, Show, Eq)
 
-instance Show a => Show (UtxoSet ctx a) where
-  show (UtxoSet set1) = show set1
-
-instance Eq a => Eq (UtxoSet ctx a) where
-  (UtxoSet set1) == (UtxoSet set2) = set1 == set2
-
-deriving instance FromJSON a => FromJSON (UtxoSet C.CtxTx a)
-deriving instance FromJSON a => FromJSON (UtxoSet C.CtxUTxO a)
-deriving instance ToJSON a => ToJSON (UtxoSet C.CtxTx a)
-deriving instance ToJSON a => ToJSON (UtxoSet C.CtxUTxO a)
-
--- FIXME (koslambrou) Remove those orphan instances and use custom type instead such as TxOutInAnyEra
-instance Show (C.InAnyCardanoEra (C.TxOut ctx)) where
-  show (C.InAnyCardanoEra _ txOut) = show txOut
-
-instance Eq (C.InAnyCardanoEra (C.TxOut ctx)) where
-  (C.InAnyCardanoEra C.ByronEra txOutL) == (C.InAnyCardanoEra C.ByronEra txOutR) = txOutL == txOutR
-  (C.InAnyCardanoEra C.ShelleyEra txOutL) == (C.InAnyCardanoEra C.ShelleyEra txOutR) = txOutL == txOutR
-  (C.InAnyCardanoEra C.AllegraEra txOutL) == (C.InAnyCardanoEra C.AllegraEra txOutR) = txOutL == txOutR
-  (C.InAnyCardanoEra C.MaryEra txOutL) == (C.InAnyCardanoEra C.MaryEra txOutR) = txOutL == txOutR
-  (C.InAnyCardanoEra C.AlonzoEra txOutL) == (C.InAnyCardanoEra C.AlonzoEra txOutR) = txOutL == txOutR
-  (C.InAnyCardanoEra C.BabbageEra txOutL) == (C.InAnyCardanoEra C.BabbageEra txOutR) = txOutL == txOutR
-  (C.InAnyCardanoEra C.ConwayEra txOutL) == (C.InAnyCardanoEra C.ConwayEra txOutR) = txOutL == txOutR
-  _ == _ = False
-
-instance ToJSON (C.InAnyCardanoEra (C.TxOut ctx)) where
-  toJSON (C.InAnyCardanoEra C.ByronEra txOut) =
-    object
-      [ "tag" .= String "ByronTxOut"
-      , "txOut" .= toJSON txOut
-      ]
-  toJSON (C.InAnyCardanoEra C.ShelleyEra txOut) =
-    object
-      [ "tag" .= String "ShelleyTxOut"
-      , "txOut" .= toJSON txOut
-      ]
-  toJSON (C.InAnyCardanoEra C.AllegraEra txOut) =
-    object
-      [ "tag" .= String "AllegraTxOut"
-      , "txOut" .= toJSON txOut
-      ]
-  toJSON (C.InAnyCardanoEra C.MaryEra txOut) =
-    object
-      [ "tag" .= String "MaryTxOut"
-      , "txOut" .= toJSON txOut
-      ]
-  toJSON (C.InAnyCardanoEra C.AlonzoEra txOut) =
-    object
-      [ "tag" .= String "AlonzoTxOut"
-      , "txOut" .= toJSON txOut
-      ]
-  toJSON (C.InAnyCardanoEra C.BabbageEra txOut) =
-    object
-      [ "tag" .= String "BabbageTxOut"
-      , "txOut" .= toJSON txOut
-      ]
-  toJSON (C.InAnyCardanoEra C.ConwayEra txOut) =
-    object
-      [ "tag" .= String "ConwayTxOut"
-      , "txOut" .= toJSON txOut
-      ]
-
-type TxOutConstraints (k :: Type -> Constraint) ctx =
-  ( k (CS.TxOut ctx CS.ShelleyEra)
-  , k (CS.TxOut ctx CS.AllegraEra)
-  , k (CS.TxOut ctx CS.MaryEra)
-  , k (CS.TxOut ctx CS.AlonzoEra)
-  , k (CS.TxOut ctx CS.BabbageEra)
-  , k (CS.TxOut ctx CS.ConwayEra)
-  )
-
--- FIXME (koslambou) Remove duplication with similar instance below
-instance TxOutConstraints FromJSON ctx => FromJSON (C.InAnyCardanoEra (C.TxOut ctx)) where
-  parseJSON = withObject "InAnyCardanoEra (C.TxOut C.CtxTx)" $ \o -> do
-    tag <- o .: "tag"
-    case tag :: Text of
-      "ShelleyTxOut" -> fmap (C.InAnyCardanoEra C.ShelleyEra) $ o .: "txOut"
-      "AllegraTxOut" -> fmap (C.InAnyCardanoEra C.AllegraEra) $ o .: "txOut"
-      "MaryTxOut" -> fmap (C.InAnyCardanoEra C.MaryEra) $ o .: "txOut"
-      "AlonzoTxOut" -> fmap (C.InAnyCardanoEra C.AlonzoEra) $ o .: "txOut"
-      "BabbageTxOut" -> fmap (C.InAnyCardanoEra C.BabbageEra) $ o .: "txOut"
-      "ConwayTxOut" -> fmap (C.InAnyCardanoEra C.ConwayEra) $ o .: "txOut"
-      _ -> fail "Expected tag to be ShelleyTxOut, AllegraTxOut, MaryTxOut, AlonzoTxOut, BabbageTxOut, ConwayTxOut"
-
--- deriving instance (FromJSON a, FromJSON (C.TxOut ctx C.BabbageEra)) => FromJSON (UtxoSet ctx a)
--- deriving instance (ToJSON a, ToJSON (C.TxOut ctx C.BabbageEra)) => ToJSON (UtxoSet ctx a)
+deriving instance (CS.IsShelleyBasedEra era, FromJSON a) => FromJSON (UtxoSet C.CtxTx era a)
+deriving instance (CS.IsShelleyBasedEra era, FromJSON a) => FromJSON (UtxoSet C.CtxUTxO era a)
+deriving instance (CS.IsCardanoEra era, ToJSON a) => ToJSON (UtxoSet C.CtxTx era a)
+deriving instance (CS.IsCardanoEra era, ToJSON a) => ToJSON (UtxoSet C.CtxUTxO era a)
 
 {-| A utxo set with one element
 -}
-singleton :: TxIn -> (C.InAnyCardanoEra (C.TxOut ctx), a) -> UtxoSet ctx a
+singleton :: TxIn -> (C.TxOut ctx era, a) -> UtxoSet ctx era a
 singleton txi = UtxoSet . Map.singleton txi
 
 {-| Change the context of the outputs in this utxo set to 'CtxUTxO'
 -}
-fromUtxoTx :: UtxoSet C.CtxTx a -> UtxoSet C.CtxUTxO a
-fromUtxoTx = UtxoSet . fmap (first fromTxOutInAnyEraTx) . _utxos
-
-fromTxOutInAnyEraTx :: C.InAnyCardanoEra (C.TxOut C.CtxTx) -> C.InAnyCardanoEra (C.TxOut C.CtxUTxO)
-fromTxOutInAnyEraTx (C.InAnyCardanoEra era txOut) = C.InAnyCardanoEra era $ C.toCtxUTxOTxOut txOut
+fromUtxoTx :: UtxoSet C.CtxTx era a -> UtxoSet C.CtxUTxO era a
+fromUtxoTx = UtxoSet . fmap (first C.toCtxUTxOTxOut) . _utxos
 
 makePrisms ''UtxoSet
 
 {-| Convert a @cardano-api@ 'UTxO BabbageEra' to a utxo set
 -}
-fromApiUtxo :: a -> C.InAnyCardanoEra UTxO -> UtxoSet C.CtxUTxO a
-fromApiUtxo v = \case
-  C.InAnyCardanoEra C.ByronEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
-  C.InAnyCardanoEra C.AllegraEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
-  C.InAnyCardanoEra C.MaryEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
-  C.InAnyCardanoEra C.ShelleyEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
-  C.InAnyCardanoEra C.AlonzoEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
-  C.InAnyCardanoEra C.BabbageEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
-  C.InAnyCardanoEra C.ConwayEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, v)) utxoSet)
+fromApiUtxo :: a -> UTxO era -> UtxoSet C.CtxUTxO era a
+fromApiUtxo v (UTxO utxoSet) = UtxoSet (fmap (, v) utxoSet)
 
 {-| Convert a utxo set to a @cardano-api@ 'UTxO BabbageEra'
 -}
-toApiUtxo :: UtxoSet C.CtxUTxO a -> UTxO C.ConwayEra
+toApiUtxo :: UtxoSet C.CtxUTxO era a -> UTxO era
 toApiUtxo (UtxoSet utxos) =
-  UTxO (fmap (toTxOut . fst) utxos)
- where
-  toTxOut :: C.InAnyCardanoEra (C.TxOut C.CtxUTxO) -> C.TxOut C.CtxUTxO C.ConwayEra
-  toTxOut (C.InAnyCardanoEra _era txOut) = utxoToLatestEra txOut
-
--- FIXME (koslambrou) Move to proper package
-txOutToLatestEra :: C.TxOut C.CtxTx era -> C.TxOut C.CtxTx C.ConwayEra
-txOutToLatestEra (C.TxOut addrInEra txOutValue txOutDatum ref) =
-  C.TxOut
-    (convertAddrToLatestEra addrInEra)
-    (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $
-      C.toLedgerValue C.MaryEraOnwardsConway $ C.txOutValueToValue txOutValue)
-    (convertDatumToLatestEra txOutDatum)
-    (convertRefScriptToLatestEra ref)
- where
-  convertAddrToLatestEra :: C.AddressInEra era -> C.AddressInEra C.ConwayEra
-  convertAddrToLatestEra (C.AddressInEra C.ByronAddressInAnyEra addr) =
-    C.AddressInEra C.ByronAddressInAnyEra addr
-  convertAddrToLatestEra (C.AddressInEra (C.ShelleyAddressInEra _) addr) =
-    C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraConway) addr
-
-  convertDatumToLatestEra :: C.TxOutDatum C.CtxTx era -> C.TxOutDatum C.CtxTx C.ConwayEra
-  convertDatumToLatestEra C.TxOutDatumNone = C.TxOutDatumNone
-  convertDatumToLatestEra (C.TxOutDatumHash _ h) = C.TxOutDatumHash C.AlonzoEraOnwardsConway h
-  convertDatumToLatestEra (C.TxOutDatumInTx _ d) = C.TxOutDatumInTx C.AlonzoEraOnwardsConway d
-  convertDatumToLatestEra (C.TxOutDatumInline _ d) = C.TxOutDatumInline C.BabbageEraOnwardsConway d
-
-  convertRefScriptToLatestEra :: CS.ReferenceScript era -> CS.ReferenceScript CS.ConwayEra
-  convertRefScriptToLatestEra CS.ReferenceScriptNone = CS.ReferenceScriptNone
-  convertRefScriptToLatestEra (CS.ReferenceScript _ script) = CS.ReferenceScript CS.BabbageEraOnwardsConway script
-
--- FIXME (koslambrou) Move to proper package
-utxoToLatestEra :: C.TxOut C.CtxUTxO era -> C.TxOut C.CtxUTxO C.ConwayEra
-utxoToLatestEra (C.TxOut addrInEra txOutValue txOutDatum ref) =
-  C.TxOut
-    (convertAddrToLatestEra addrInEra)
-    (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $
-      C.toLedgerValue C.MaryEraOnwardsConway $ C.txOutValueToValue txOutValue)
-    (convertDatumToLatestEra txOutDatum)
-    (convertRefScriptToLatestEra ref)
- where
-  convertAddrToLatestEra :: C.AddressInEra era -> C.AddressInEra C.ConwayEra
-  convertAddrToLatestEra (C.AddressInEra C.ByronAddressInAnyEra addr) =
-    C.AddressInEra C.ByronAddressInAnyEra addr
-  convertAddrToLatestEra (C.AddressInEra (C.ShelleyAddressInEra _) addr) =
-    C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraConway) addr
-
-  convertDatumToLatestEra :: C.TxOutDatum C.CtxUTxO era -> C.TxOutDatum C.CtxUTxO C.ConwayEra
-  convertDatumToLatestEra C.TxOutDatumNone = C.TxOutDatumNone
-  convertDatumToLatestEra (C.TxOutDatumHash _ h) = C.TxOutDatumHash C.AlonzoEraOnwardsConway h
-  convertDatumToLatestEra (C.TxOutDatumInline _ d) = C.TxOutDatumInline C.BabbageEraOnwardsConway d
-
-  convertRefScriptToLatestEra :: CS.ReferenceScript era -> CS.ReferenceScript CS.ConwayEra
-  convertRefScriptToLatestEra CS.ReferenceScriptNone = CS.ReferenceScriptNone
-  convertRefScriptToLatestEra (CS.ReferenceScript _ script) = CS.ReferenceScript CS.BabbageEraOnwardsConway script
-
+  UTxO (fmap fst utxos)
 
 {-| Pick an unspent output from the 'UtxoSet', if there is one.
 -}
-selectUtxo :: UtxoSet ctx a -> Maybe (C.TxIn, (C.InAnyCardanoEra (C.TxOut ctx), a))
+selectUtxo :: UtxoSet ctx era a -> Maybe (C.TxIn, (C.TxOut ctx era, a))
 selectUtxo =
   -- sorting by key is pretty much a random order
   listToMaybe . Map.toAscList . _utxos
 
 {-| Restrict the 'UtxoSet' to outputs that only have Ada values (no native assets)
 -}
-onlyAda :: UtxoSet ctx a -> UtxoSet ctx a
+onlyAda :: UtxoSet ctx era a -> UtxoSet ctx era a
 onlyAda =
-  let txOutHasOnlyAda :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
-      txOutHasOnlyAda (C.InAnyCardanoEra _ txOut, _) =
+  let txOutHasOnlyAda :: (C.TxOut ctx era, a) -> Bool
+      txOutHasOnlyAda (txOut, _) =
         isJust $ C.valueToLovelace $ C.txOutValueToValue $ view (L._TxOut . _2) txOut
   in fst . partition txOutHasOnlyAda
 
 {-| Partition the UtxoSet according to a predicate. The first UtxoSet contains all
 utxos that satisfy the predicate, the second all utxos that fail the predicate.
 -}
-partition :: ((C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool) -> UtxoSet ctx a -> (UtxoSet ctx a, UtxoSet ctx a)
+partition :: ((C.TxOut ctx era, a) -> Bool) -> UtxoSet ctx era a -> (UtxoSet ctx era a, UtxoSet ctx era a)
 partition p (UtxoSet s) =
   bimap UtxoSet UtxoSet (Map.partition p s)
 
 {-| Restrict the 'UtxoSet' to outputs at the address
 -}
-onlyAddress :: C.AddressAny -> UtxoSet ctx a -> UtxoSet ctx a
+onlyAddress :: C.AddressAny -> UtxoSet ctx era a -> UtxoSet ctx era a
 onlyAddress expectedAddr =
-  let txOutHasAddr :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
-      txOutHasAddr (C.InAnyCardanoEra _ (C.TxOut addrInEra _ _ _), _) =
+  let txOutHasAddr :: (C.TxOut ctx era, a) -> Bool
+      txOutHasAddr (C.TxOut addrInEra _ _ _, _) =
         case addrInEra of
           C.AddressInEra C.ByronAddressInAnyEra addr -> expectedAddr == C.toAddressAny addr
           C.AddressInEra (C.ShelleyAddressInEra _) addr -> expectedAddr == C.toAddressAny addr
@@ -330,29 +179,29 @@ onlyAddress expectedAddr =
 
 {-| Restrict the utxo set to outputs with the given payment credential
 -}
-onlyCredential :: C.PaymentCredential -> UtxoSet ctx a -> UtxoSet ctx a
+onlyCredential :: C.PaymentCredential -> UtxoSet ctx era a -> UtxoSet ctx era a
 onlyCredential c = onlyCredentials (Set.singleton c)
 
 {-| Restrict the utxo set to outputs locked by one of the given payment credentials
 -}
-onlyCredentials :: Set (C.PaymentCredential) -> UtxoSet ctx a -> UtxoSet ctx a
+onlyCredentials :: Set (C.PaymentCredential) -> UtxoSet ctx era a -> UtxoSet ctx era a
 onlyCredentials cs =
-  let txOutHasOneOfCreds :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
-      txOutHasOneOfCreds (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _), _) =
+  let txOutHasOneOfCreds :: (C.TxOut ctx era, a) -> Bool
+      txOutHasOneOfCreds (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _, _) =
         False
-      txOutHasOneOfCreds (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _), _) =
+      txOutHasOneOfCreds (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _, _) =
         let (CS.ShelleyAddress _ (CS.fromShelleyPaymentCredential -> c) _) = addr
          in c `Set.member` cs
   in fst . partition txOutHasOneOfCreds
 
 {-| Restrict the utxo set to outputs with the given stake credential
 -}
-onlyStakeCredential :: StakeCredential -> UtxoSet ctx a -> UtxoSet ctx a
+onlyStakeCredential :: StakeCredential -> UtxoSet ctx era a -> UtxoSet ctx era a
 onlyStakeCredential expectedStakeCredential =
-  let txOutHasStakeCred :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
-      txOutHasStakeCred (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _), _) =
+  let txOutHasStakeCred :: (C.TxOut ctx era, a) -> Bool
+      txOutHasStakeCred (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _, _) =
         False
-      txOutHasStakeCred (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _), _) =
+      txOutHasStakeCred (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _, _) =
         let (CS.ShelleyAddress _ _ (CS.fromShelleyStakeReference -> stakeRef)) = addr
          in case stakeRef of
               C.StakeAddressByValue stakeCred -> expectedStakeCredential == stakeCred
@@ -362,12 +211,12 @@ onlyStakeCredential expectedStakeCredential =
 
 {-| Restrict the 'UtxoSet' to public key outputs
 -}
-onlyPubKey :: UtxoSet ctx a -> UtxoSet ctx a
+onlyPubKey :: UtxoSet ctx era a -> UtxoSet ctx era a
 onlyPubKey =
-  let txOutHasPubKeyAddr :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
-      txOutHasPubKeyAddr (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _), _) =
+  let txOutHasPubKeyAddr :: (C.TxOut ctx era, a) -> Bool
+      txOutHasPubKeyAddr (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _, _) =
         False
-      txOutHasPubKeyAddr (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _), _) =
+      txOutHasPubKeyAddr (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _, _) =
         let (CS.ShelleyAddress _ (CS.fromShelleyPaymentCredential -> cred) _) = addr
          in case cred of
               C.PaymentCredentialByKey _    -> True
@@ -376,79 +225,79 @@ onlyPubKey =
 
 {-| The combined 'Value' of all outputs in the set
 -}
-totalBalance :: UtxoSet ctx a -> C.Value
+totalBalance :: UtxoSet ctx era a -> C.Value
 totalBalance =
-  foldMap (\(C.InAnyCardanoEra _era (C.TxOut _ txOutValue _ _), _) -> C.txOutValueToValue txOutValue) . _utxos
+  foldMap (\(C.TxOut _ txOutValue _ _, _) -> C.txOutValueToValue txOutValue) . _utxos
 
 {-| Delete some outputs from the 'UtxoSet'
 -}
-removeUtxos :: Set.Set C.TxIn -> UtxoSet ctx a -> UtxoSet ctx a
+removeUtxos :: Set.Set C.TxIn -> UtxoSet ctx era a -> UtxoSet ctx era a
 removeUtxos ins = over _UtxoSet (flip Map.withoutKeys ins)
 
 {-| A change to the UTxO set, adding and/or removing UTxOs
 -}
-data UtxoChange ctx a =
+data UtxoChange ctx era a =
   UtxoChange
-    { _outputsAdded   :: !(Map C.TxIn (C.InAnyCardanoEra (C.TxOut ctx), a))
-    , _outputsRemoved :: !(Map C.TxIn (C.InAnyCardanoEra (C.TxOut ctx), a))
+    { _outputsAdded   :: !(Map C.TxIn (C.TxOut ctx era, a))
+    , _outputsRemoved :: !(Map C.TxIn (C.TxOut ctx era, a))
     }
 
 {-| Change the context of the outputs in this utxo change
 -}
-toUtxoChangeTx :: UtxoChange C.CtxTx a -> UtxoChange C.CtxUTxO a
+toUtxoChangeTx :: UtxoChange C.CtxTx era a -> UtxoChange C.CtxUTxO era a
 toUtxoChangeTx (UtxoChange added removed) =
-  UtxoChange (fmap (first fromTxOutInAnyEraTx) added) (fmap (first fromTxOutInAnyEraTx) removed)
+  UtxoChange (fmap (first C.toCtxUTxOTxOut) added) (fmap (first C.toCtxUTxOTxOut) removed)
 
 makeLenses ''UtxoChange
 -- TODO: change '<>' so that @x <> invert x == mempty@ and @invert x <> x == mempty@
 
-instance Semigroup (UtxoChange ctx a) where
+instance Semigroup (UtxoChange ctx era a) where
   l <> r =
     UtxoChange
       { _outputsAdded   = _outputsAdded l <> _outputsAdded r
       , _outputsRemoved = _outputsRemoved l <> _outputsRemoved r
       }
 
-instance Monoid (UtxoChange ctx a) where
+instance Monoid (UtxoChange ctx era a) where
   mempty = UtxoChange mempty mempty
 
 {-| Is this the empty 'UtxoChange'?
 -}
-null :: UtxoChange ctx a -> Bool
+null :: UtxoChange ctx era a -> Bool
 null UtxoChange{_outputsAdded, _outputsRemoved} = Map.null _outputsAdded && Map.null _outputsRemoved
 
 {-| An event that caused the utxo set to change
 -}
-type UtxoChangeEvent a = Either (AddUtxoEvent a) (RemoveUtxoEvent a)
+type UtxoChangeEvent era a = Either (AddUtxoEvent era a) (RemoveUtxoEvent era a)
 
 {-| A new tx out was added
 -}
-data AddUtxoEvent a =
+data AddUtxoEvent era a =
   AddUtxoEvent
     { aueEvent :: !a
-    , aueTxOut :: !(C.InAnyCardanoEra (C.TxOut C.CtxTx))
+    , aueTxOut :: !(C.TxOut C.CtxTx era)
     , aueTxIn  :: !TxIn
     , aueTxId  :: !TxId
-    , aueTx    :: !(C.InAnyCardanoEra C.Tx)
+    , aueTx    :: !(C.Tx era)
     }
 
 {-| A tx output was spent
 -}
-data RemoveUtxoEvent a =
+data RemoveUtxoEvent era a =
   RemoveUtxoEvent
     { rueEvent    :: !a
-    , rueTxOut    :: !(C.InAnyCardanoEra (C.TxOut C.CtxTx))
+    , rueTxOut    :: !(C.TxOut C.CtxTx era)
     , rueTxIn     :: !TxIn
     , rueTxId     :: !TxId
     -- ^ Id of the transaction that spent the output
-    , rueTx       :: !(C.InAnyCardanoEra C.Tx)
+    , rueTx       :: !(C.Tx era)
     -- ^ The transaction that spent the output
     , rueRedeemer :: Maybe (HashableScriptData, ExecutionUnits) -- fromAlonzoData
     }
 
 {-| The 'UtxoChange' represented by the event.
 -}
-fromEvent :: UtxoChangeEvent a -> UtxoChange C.CtxTx a
+fromEvent :: UtxoChangeEvent era a -> UtxoChange C.CtxTx era a
 fromEvent = \case
   Left AddUtxoEvent{aueEvent, aueTxOut, aueTxIn} ->
     let ch = Map.singleton aueTxIn (aueTxOut, aueEvent)
@@ -459,7 +308,7 @@ fromEvent = \case
 
 {-| ID of the transaction that caused the event
 -}
-txId :: UtxoChangeEvent a -> TxId
+txId :: UtxoChangeEvent era a -> TxId
 txId = either aueTxId rueTxId
 
 {-| A type capturing the effect a 'UtxoChange' has on the total balance of each address that it touches
@@ -503,11 +352,11 @@ instance Monoid BalanceChanges where
 
 {-| The change in currency affected by the 'UtxoChange' on each address
 -}
-balanceChange :: UtxoChange ctx a -> BalanceChanges
+balanceChange :: UtxoChange ctx era a -> BalanceChanges
 balanceChange UtxoChange{_outputsAdded, _outputsRemoved} =
-  let k :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Maybe (C.PaymentCredential, C.Value)
-      k (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _), _) = Nothing
-      k (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) txOutValue _ _), _) =
+  let k :: (C.TxOut ctx era, a) -> Maybe (C.PaymentCredential, C.Value)
+      k (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _, _) = Nothing
+      k (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) txOutValue _ _, _) =
         let (CS.ShelleyAddress _ (CS.fromShelleyPaymentCredential -> cred) _) = addr
          in Just (cred, C.txOutValueToValue txOutValue)
       tv = Map.fromListWith (<>) . mapMaybe (k . snd) . Map.toList
@@ -530,16 +379,16 @@ changeFor cred (BalanceChanges c) = Map.findWithDefault mempty cred c
 
 {-| Describe the UtxoChange
 -}
-describeChange :: UtxoChange ctx a -> Text
+describeChange :: UtxoChange ctx era a -> Text
 describeChange UtxoChange{_outputsAdded, _outputsRemoved} =
   let tshow = Text.pack . show
   in tshow (Map.size _outputsAdded) <> " outputs added, " <> tshow (Map.size _outputsRemoved) <> " outputs removed"
 
-newtype PrettyUtxoChange ctx a = PrettyUtxoChange (UtxoChange ctx a)
+newtype PrettyUtxoChange ctx era a = PrettyUtxoChange (UtxoChange ctx era a)
 
-instance Pretty a => Pretty (PrettyUtxoChange ctx a) where
+instance Pretty a => Pretty (PrettyUtxoChange ctx era a) where
   pretty (PrettyUtxoChange UtxoChange{_outputsAdded, _outputsRemoved}) =
-    let b = foldMap (\((C.InAnyCardanoEra _ (C.TxOut _ txOutValue _ _)), _) -> C.txOutValueToValue txOutValue)
+    let b = foldMap (\((C.TxOut _ txOutValue _ _), _) -> C.txOutValueToValue txOutValue)
         bPlus = b _outputsAdded
         bMinus = C.negateValue (b _outputsRemoved)
     in Prettyprinter.hsep $
@@ -548,9 +397,9 @@ instance Pretty a => Pretty (PrettyUtxoChange ctx a) where
         , pretty (Map.size _outputsRemoved), "outputs removed."]
         ++ prettyValue (bPlus <> bMinus)
 
-newtype PrettyBalance ctx  a = PrettyBalance (UtxoSet ctx a)
+newtype PrettyBalance ctx era a = PrettyBalance (UtxoSet ctx era a)
 
-instance Pretty a => Pretty (PrettyBalance ctx a) where
+instance Pretty a => Pretty (PrettyBalance ctx era a) where
   pretty (PrettyBalance bal) =
     let nOutputs = Map.size (_utxos bal)
     in hang 4 $ vsep
@@ -559,80 +408,73 @@ instance Pretty a => Pretty (PrettyBalance ctx a) where
 
 {-| Change the 'UtxoSet'
 -}
-apply :: UtxoSet ctx a -> UtxoChange ctx a -> UtxoSet ctx a
+apply :: UtxoSet ctx era a -> UtxoChange ctx era a -> UtxoSet ctx era a
 apply UtxoSet{_utxos} UtxoChange{_outputsAdded, _outputsRemoved} =
   UtxoSet $ (_utxos `Map.union` _outputsAdded) `Map.difference` _outputsRemoved
 
 {-| Invert a 'UtxoChange' value
 -}
-inv :: UtxoChange ctx a -> UtxoChange ctx a
+inv :: UtxoChange ctx era a -> UtxoChange ctx era a
 inv (UtxoChange added removed) = UtxoChange removed added
 
 {-| Extract from a block the UTXO changes at the given address. Returns the
 'UtxoChange' itself and a set of all transactions that affected the change.
 -}
-extract :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a) -> Maybe AddressCredential -> UtxoSet C.CtxTx a -> BlockInMode -> [UtxoChangeEvent a]
-extract ex cred state = DList.toList . \case
-  -- FIXME (koslambrou) why is this only extracting from babbage?
-  BlockInMode C.BabbageEra block -> extractBabbage ex state cred block
-  BlockInMode C.ConwayEra  block -> extractConway ex state cred block
-  _                              -> mempty
+-- TODO make better polymorphic
+extract :: forall era a. C.IsCardanoEra era => (C.TxIn -> C.TxOut C.CtxTx era -> Maybe a) -> Maybe AddressCredential -> UtxoSet C.CtxTx era a -> Block era -> [UtxoChangeEvent era a]
+extract ex cred state block@(CS.Block _blockHeader txns) = DList.toList $ case C.cardanoEra @era of
+  C.BabbageEra -> extractBabbage ex state cred block
+  C.ConwayEra  -> foldMap (extractConwayTxn' ex state cred) txns
+  _            -> mempty
 
 {-| Extract from a block the UTXO changes at the given address
 -}
-extract_ :: AddressCredential -> UtxoSet C.CtxTx () -> BlockInMode -> UtxoChange C.CtxTx ()
+extract_ :: C.IsCardanoEra era => AddressCredential -> UtxoSet C.CtxTx era () -> Block era -> UtxoChange C.CtxTx era ()
 extract_ a b = foldMap fromEvent . extract (\_ -> const $ Just ()) (Just a) b
 
-extractConway
-  :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
-  -> UtxoSet C.CtxTx a
-  -> Maybe AddressCredential
-  -> Block ConwayEra
-  -> DList (UtxoChangeEvent a)
-extractConway ex state cred (CS.Block _blockHeader txns) = foldMap (extractConwayTxn' ex state cred) txns
 
-checkOutput :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a) -> TxId -> Maybe AddressCredential -> TxIx -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe (TxIn, (C.InAnyCardanoEra (C.TxOut C.CtxTx), a))
-checkOutput _ex _txid _cred _ (C.InAnyCardanoEra _era (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _)) = Nothing
-checkOutput ex txid cred txIx_ (C.InAnyCardanoEra era txOut@(C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) (CS.ShelleyAddress _ outputCred _)) _ _ _))
+checkOutput :: (C.TxIn -> C.TxOut C.CtxTx era -> Maybe a) -> TxId -> Maybe AddressCredential -> TxIx -> C.TxOut C.CtxTx era -> Maybe (TxIn, (C.TxOut C.CtxTx era, a))
+checkOutput _ex _txid _cred _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _) = Nothing
+checkOutput ex txid cred txIx_ txOut@(C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) (CS.ShelleyAddress _ outputCred _)) _ _ _)
   | isNothing cred || Just outputCred == cred =
       let txi = TxIn txid txIx_
-      in fmap (\a -> (txi, (C.InAnyCardanoEra era txOut, a))) (ex txi $ C.InAnyCardanoEra era txOut)
+      in fmap (\a -> (txi, (txOut, a))) (ex txi txOut)
   | otherwise = Nothing
 
-mkI :: TxId -> CS.InAnyCardanoEra Tx -> (TxIn, (CS.InAnyCardanoEra (CS.TxOut CS.CtxTx), a)) -> AddUtxoEvent a
+mkI :: TxId -> Tx era -> (TxIn, (CS.TxOut CS.CtxTx era, a)) -> AddUtxoEvent era a
 mkI txid tx (aueTxIn, (aueTxOut, aueEvent)) = AddUtxoEvent{aueEvent, aueTxOut, aueTxIn, aueTxId = txid, aueTx = tx}
 
-mkO :: TxId -> CS.InAnyCardanoEra Tx -> (TxIn, ((CS.InAnyCardanoEra (CS.TxOut CS.CtxTx), a), Maybe (HashableScriptData, ExecutionUnits))) -> RemoveUtxoEvent a
+mkO :: TxId -> Tx era -> (TxIn, ((CS.TxOut CS.CtxTx era, a), Maybe (HashableScriptData, ExecutionUnits))) -> RemoveUtxoEvent era a
 mkO txid tx (rueTxIn, ((rueTxOut, rueEvent), rueRedeemer)) = RemoveUtxoEvent{rueEvent, rueTxOut, rueTxIn, rueTxId = txid, rueTx = tx, rueRedeemer}
 
 {-| Extract from a conway-era transaction the UTXO changes at the given address
  -}
 extractConwayTxn
-  :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
+  :: (C.TxIn -> C.TxOut C.CtxTx ConwayEra -> Maybe a)
   -> Maybe AddressCredential
-  -> UtxoSet C.CtxTx a
+  -> UtxoSet C.CtxTx ConwayEra a
   -> C.Tx ConwayEra
-  -> [UtxoChangeEvent a]
+  -> [UtxoChangeEvent ConwayEra a]
 extractConwayTxn ex cred state = DList.toList . extractConwayTxn' ex state cred
 
 extractConwayTxn'
-  :: forall a. (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
-  -> UtxoSet C.CtxTx a
+  :: forall a. (C.TxIn -> C.TxOut C.CtxTx ConwayEra -> Maybe a)
+  -> UtxoSet C.CtxTx ConwayEra a
   -> Maybe AddressCredential
   -> C.Tx ConwayEra
-  -> DList (UtxoChangeEvent a)
+  -> DList (UtxoChangeEvent ConwayEra a)
 extractConwayTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
   let ShelleyTxBody _ txBody' _scripts scriptData _auxiliaryData _ = txBody
       Conway.TxBody.ConwayTxBody{Conway.TxBody.ctbSpendInputs} = txBody'
       txid = C.getTxId txBody
 
-      allOuts = fmap (C.InAnyCardanoEra C.ConwayEra) $ C.fromLedgerTxOuts C.ShelleyBasedEraConway txBody' scriptData
+      allOuts = C.fromLedgerTxOuts C.shelleyBasedEra txBody' scriptData
 
       txReds = case scriptData of
               C.TxBodyScriptData _ _ r -> r
               _                        -> mempty
 
-      checkInput :: (Word32, TxIn) -> Maybe (TxIn, ((C.InAnyCardanoEra (C.TxOut C.CtxTx), a), Maybe (HashableScriptData, ExecutionUnits)))
+      checkInput :: (Word32, TxIn) -> Maybe (TxIn, ((C.TxOut C.CtxTx ConwayEra, a), Maybe (HashableScriptData, ExecutionUnits)))
       checkInput (idx, txIn) = fmap (txIn,) $ do
         o <- Map.lookup txIn _utxos
         let redeemer = fmap (bimap CS.fromAlonzoData CS.fromAlonzoExUnits) (Alonzo.TxWits.lookupRedeemer (Scripts.Conway.ConwaySpending $ Scripts.AsIx idx) txReds)
@@ -640,13 +482,13 @@ extractConwayTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
 
       _outputsAdded =
         DList.fromList
-        $ fmap (Left . mkI txid (C.inAnyCardanoEra C.ConwayEra theTx))
+        $ fmap (Left . mkI txid theTx)
         $ mapMaybe (uncurry (checkOutput ex txid cred))
         $ zip (TxIx <$> [0..]) allOuts
 
       _outputsRemoved =
         DList.fromList
-        $ fmap (Right . mkO txid (C.inAnyCardanoEra C.ConwayEra theTx))
+        $ fmap (Right . mkO txid theTx)
         $ mapMaybe checkInput
         $ zip [0..] -- for redeemer pointers
         $ fmap (uncurry TxIn . bimap CS.fromShelleyTxId txIx . (\(CT.TxIn i n) -> (i, n)))
@@ -655,41 +497,41 @@ extractConwayTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
   in _outputsAdded <> _outputsRemoved
 
 extractBabbage
-  :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
-  -> UtxoSet C.CtxTx a
+  :: (C.TxIn -> C.TxOut C.CtxTx BabbageEra -> Maybe a)
+  -> UtxoSet C.CtxTx BabbageEra a
   -> Maybe AddressCredential
   -> Block BabbageEra
-  -> DList (UtxoChangeEvent a)
+  -> DList (UtxoChangeEvent BabbageEra a)
 extractBabbage ex state cred (CS.Block _blockHeader txns) = foldMap (extractBabbageTxn' ex state cred) txns
 
 {-| Extract from a transaction the UTXO changes at the given address
  -}
 extractBabbageTxn
-  :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
+  :: (C.TxIn -> C.TxOut C.CtxTx BabbageEra -> Maybe a)
   -> Maybe AddressCredential
-  -> UtxoSet C.CtxTx a
+  -> UtxoSet C.CtxTx BabbageEra a
   -> C.Tx BabbageEra
-  -> [UtxoChangeEvent a]
+  -> [UtxoChangeEvent BabbageEra a]
 extractBabbageTxn ex cred state = DList.toList . extractBabbageTxn' ex state cred
 
 extractBabbageTxn'
-  :: forall a. (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
-  -> UtxoSet C.CtxTx a
+  :: forall a. (C.TxIn -> C.TxOut C.CtxTx BabbageEra -> Maybe a)
+  -> UtxoSet C.CtxTx BabbageEra a
   -> Maybe AddressCredential
   -> C.Tx BabbageEra
-  -> DList (UtxoChangeEvent a)
+  -> DList (UtxoChangeEvent BabbageEra a)
 extractBabbageTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
   let ShelleyTxBody _ txBody' _scripts scriptData _auxiliaryData _ = txBody
       Babbage.TxBody.BabbageTxBody{Babbage.TxBody.btbInputs} = txBody'
       txid = C.getTxId txBody
 
-      allOuts = fmap (C.InAnyCardanoEra C.BabbageEra) $ C.fromLedgerTxOuts C.ShelleyBasedEraBabbage txBody' scriptData
+      allOuts = C.fromLedgerTxOuts C.shelleyBasedEra txBody' scriptData
 
       txReds = case scriptData of
               C.TxBodyScriptData _ _ r -> unRedeemers r
               _                        -> mempty
 
-      checkInput :: (Word32, TxIn) -> Maybe (TxIn, ((C.InAnyCardanoEra (C.TxOut C.CtxTx), a), Maybe (HashableScriptData, ExecutionUnits)))
+      checkInput :: (Word32, TxIn) -> Maybe (TxIn, ((C.TxOut C.CtxTx BabbageEra, a), Maybe (HashableScriptData, ExecutionUnits)))
       checkInput (idx, txIn) = fmap (txIn,) $ do
         o <- Map.lookup txIn _utxos
         let redeemer = fmap (bimap CS.fromAlonzoData CS.fromAlonzoExUnits) (Map.lookup (Scripts.AlonzoSpending $ Scripts.AsIx idx) txReds)
@@ -697,13 +539,13 @@ extractBabbageTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
 
       _outputsAdded =
         DList.fromList
-        $ fmap (Left . mkI txid (C.inAnyCardanoEra C.BabbageEra theTx))
+        $ fmap (Left . mkI txid theTx)
         $ mapMaybe (uncurry (checkOutput ex txid cred))
         $ zip (TxIx <$> [0..]) allOuts
 
       _outputsRemoved =
         DList.fromList
-        $ fmap (Right . mkO txid (C.inAnyCardanoEra C.BabbageEra theTx))
+        $ fmap (Right . mkO txid theTx)
         $ mapMaybe checkInput
         $ zip [0..] -- for redeemer pointers
         $ fmap (uncurry TxIn . bimap CS.fromShelleyTxId txIx . (\(CT.TxIn i n) -> (i, n)))

--- a/src/base/lib/Convex/Utxos.hs
+++ b/src/base/lib/Convex/Utxos.hs
@@ -35,6 +35,9 @@ module Convex.Utxos(
   removeUtxos,
   fromApiUtxo,
   toApiUtxo,
+  toTxOut,
+  txOutToLatestEra,
+  utxoToLatestEra,
   selectUtxo,
 
   -- * Events based on transactions
@@ -68,8 +71,8 @@ module Convex.Utxos(
   ) where
 
 import           Cardano.Api                   (AddressInEra, BabbageEra,
-                                                Block (..), ConwayEra,
-                                                HashableScriptData,
+                                                Block (..), BlockInMode (..),
+                                                ConwayEra, HashableScriptData,
                                                 PaymentCredential,
                                                 StakeCredential, Tx (..), TxId,
                                                 TxIn (..), TxIx (..), UTxO (..))
@@ -89,10 +92,14 @@ import qualified Cardano.Ledger.TxIn           as CT
 import           Control.Lens                  (_2, makeLenses, makePrisms,
                                                 over, preview, view)
 import qualified Convex.CardanoApi.Lenses      as L
-import           Data.Aeson                    (FromJSON, ToJSON)
+import           Convex.Utils                  (inBabbage)
+import           Data.Aeson                    (FromJSON (..), ToJSON (..),
+                                                Value (..), object, withObject,
+                                                (.:), (.=))
 import           Data.Bifunctor                (Bifunctor (..))
 import           Data.DList                    (DList)
 import qualified Data.DList                    as DList
+import           Data.Kind                     (Constraint, Type)
 import           Data.Map.Strict               (Map)
 import qualified Data.Map.Strict               as Map
 import           Data.Maybe                    (isJust, isNothing, listToMaybe,
@@ -111,67 +118,210 @@ type AddressCredential = Shelley.PaymentCredential StandardCrypto
 
 {-| A set of unspent transaction outputs
 -}
-newtype UtxoSet ctx era a = UtxoSet{ _utxos :: Map C.TxIn (C.TxOut ctx era, a) }
+newtype UtxoSet ctx a = UtxoSet{ _utxos :: Map C.TxIn (C.InAnyCardanoEra (C.TxOut ctx), a) }
   deriving stock (Functor)
-  deriving newtype (Semigroup, Monoid, Show, Eq)
+  deriving newtype (Semigroup, Monoid)
 
-deriving instance (CS.IsShelleyBasedEra era, FromJSON a) => FromJSON (UtxoSet C.CtxTx era a)
-deriving instance (CS.IsShelleyBasedEra era, FromJSON a) => FromJSON (UtxoSet C.CtxUTxO era a)
-deriving instance (CS.IsCardanoEra era, ToJSON a) => ToJSON (UtxoSet C.CtxTx era a)
-deriving instance (CS.IsCardanoEra era, ToJSON a) => ToJSON (UtxoSet C.CtxUTxO era a)
+instance Show a => Show (UtxoSet ctx a) where
+  show (UtxoSet set1) = show set1
+
+instance Eq a => Eq (UtxoSet ctx a) where
+  (UtxoSet set1) == (UtxoSet set2) = set1 == set2
+
+deriving instance FromJSON a => FromJSON (UtxoSet C.CtxTx a)
+deriving instance FromJSON a => FromJSON (UtxoSet C.CtxUTxO a)
+deriving instance ToJSON a => ToJSON (UtxoSet C.CtxTx a)
+deriving instance ToJSON a => ToJSON (UtxoSet C.CtxUTxO a)
+
+-- FIXME (koslambrou) Remove those orphan instances and use custom type instead such as TxOutInAnyEra
+instance Show (C.InAnyCardanoEra (C.TxOut ctx)) where
+  show (C.InAnyCardanoEra _ txOut) = show txOut
+
+instance Eq (C.InAnyCardanoEra (C.TxOut ctx)) where
+  (C.InAnyCardanoEra C.ByronEra txOutL) == (C.InAnyCardanoEra C.ByronEra txOutR) = txOutL == txOutR
+  (C.InAnyCardanoEra C.ShelleyEra txOutL) == (C.InAnyCardanoEra C.ShelleyEra txOutR) = txOutL == txOutR
+  (C.InAnyCardanoEra C.AllegraEra txOutL) == (C.InAnyCardanoEra C.AllegraEra txOutR) = txOutL == txOutR
+  (C.InAnyCardanoEra C.MaryEra txOutL) == (C.InAnyCardanoEra C.MaryEra txOutR) = txOutL == txOutR
+  (C.InAnyCardanoEra C.AlonzoEra txOutL) == (C.InAnyCardanoEra C.AlonzoEra txOutR) = txOutL == txOutR
+  (C.InAnyCardanoEra C.BabbageEra txOutL) == (C.InAnyCardanoEra C.BabbageEra txOutR) = txOutL == txOutR
+  (C.InAnyCardanoEra C.ConwayEra txOutL) == (C.InAnyCardanoEra C.ConwayEra txOutR) = txOutL == txOutR
+  _ == _ = False
+
+instance ToJSON (C.InAnyCardanoEra (C.TxOut ctx)) where
+  toJSON (C.InAnyCardanoEra C.ByronEra txOut) =
+    object
+      [ "tag" .= String "ByronTxOut"
+      , "txOut" .= toJSON txOut
+      ]
+  toJSON (C.InAnyCardanoEra C.ShelleyEra txOut) =
+    object
+      [ "tag" .= String "ShelleyTxOut"
+      , "txOut" .= toJSON txOut
+      ]
+  toJSON (C.InAnyCardanoEra C.AllegraEra txOut) =
+    object
+      [ "tag" .= String "AllegraTxOut"
+      , "txOut" .= toJSON txOut
+      ]
+  toJSON (C.InAnyCardanoEra C.MaryEra txOut) =
+    object
+      [ "tag" .= String "MaryTxOut"
+      , "txOut" .= toJSON txOut
+      ]
+  toJSON (C.InAnyCardanoEra C.AlonzoEra txOut) =
+    object
+      [ "tag" .= String "AlonzoTxOut"
+      , "txOut" .= toJSON txOut
+      ]
+  toJSON (C.InAnyCardanoEra C.BabbageEra txOut) =
+    object
+      [ "tag" .= String "BabbageTxOut"
+      , "txOut" .= toJSON txOut
+      ]
+  toJSON (C.InAnyCardanoEra C.ConwayEra txOut) =
+    object
+      [ "tag" .= String "ConwayTxOut"
+      , "txOut" .= toJSON txOut
+      ]
+
+type TxOutConstraints (k :: Type -> Constraint) ctx =
+  ( k (CS.TxOut ctx CS.ShelleyEra)
+  , k (CS.TxOut ctx CS.AllegraEra)
+  , k (CS.TxOut ctx CS.MaryEra)
+  , k (CS.TxOut ctx CS.AlonzoEra)
+  , k (CS.TxOut ctx CS.BabbageEra)
+  , k (CS.TxOut ctx CS.ConwayEra)
+  )
+
+-- FIXME (koslambou) Remove duplication with similar instance below
+instance TxOutConstraints FromJSON ctx => FromJSON (C.InAnyCardanoEra (C.TxOut ctx)) where
+  parseJSON = withObject "InAnyCardanoEra (C.TxOut C.CtxTx)" $ \o -> do
+    tag <- o .: "tag"
+    case tag :: Text of
+      "ShelleyTxOut" -> fmap (C.InAnyCardanoEra C.ShelleyEra) $ o .: "txOut"
+      "AllegraTxOut" -> fmap (C.InAnyCardanoEra C.AllegraEra) $ o .: "txOut"
+      "MaryTxOut"    -> fmap (C.InAnyCardanoEra C.MaryEra) $ o .: "txOut"
+      "AlonzoTxOut"  -> fmap (C.InAnyCardanoEra C.AlonzoEra) $ o .: "txOut"
+      "BabbageTxOut" -> fmap (C.InAnyCardanoEra C.BabbageEra) $ o .: "txOut"
+      "ConwayTxOut"  -> fmap (C.InAnyCardanoEra C.ConwayEra) $ o .: "txOut"
+      _ -> fail "Expected tag to be ShelleyTxOut, AllegraTxOut, MaryTxOut, AlonzoTxOut, BabbageTxOut, ConwayTxOut"
 
 {-| A utxo set with one element
 -}
-singleton :: TxIn -> (C.TxOut ctx era, a) -> UtxoSet ctx era a
-singleton txi = UtxoSet . Map.singleton txi
+singleton :: CS.IsCardanoEra era => TxIn -> (C.TxOut ctx era, a) -> UtxoSet ctx a
+singleton txi = UtxoSet . Map.singleton txi . first (C.InAnyCardanoEra C.cardanoEra)
 
 {-| Change the context of the outputs in this utxo set to 'CtxUTxO'
 -}
-fromUtxoTx :: UtxoSet C.CtxTx era a -> UtxoSet C.CtxUTxO era a
-fromUtxoTx = UtxoSet . fmap (first C.toCtxUTxOTxOut) . _utxos
+fromUtxoTx :: UtxoSet C.CtxTx a -> UtxoSet C.CtxUTxO a
+fromUtxoTx = UtxoSet . fmap (first fromTxOutInAnyEraTx) . _utxos
+
+fromTxOutInAnyEraTx :: C.InAnyCardanoEra (C.TxOut C.CtxTx) -> C.InAnyCardanoEra (C.TxOut C.CtxUTxO)
+fromTxOutInAnyEraTx (C.InAnyCardanoEra era txOut) = C.InAnyCardanoEra era $ C.toCtxUTxOTxOut txOut
 
 makePrisms ''UtxoSet
 
 {-| Convert a @cardano-api@ 'UTxO BabbageEra' to a utxo set
 -}
-fromApiUtxo :: a -> UTxO era -> UtxoSet C.CtxUTxO era a
-fromApiUtxo v (UTxO utxoSet) = UtxoSet (fmap (, v) utxoSet)
+fromApiUtxo :: CS.IsCardanoEra era => UTxO era -> UtxoSet C.CtxUTxO ()
+fromApiUtxo (C.InAnyCardanoEra C.cardanoEra -> u) = case u of
+  C.InAnyCardanoEra C.ByronEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, ())) utxoSet)
+  C.InAnyCardanoEra C.AllegraEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, ())) utxoSet)
+  C.InAnyCardanoEra C.MaryEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, ())) utxoSet)
+  C.InAnyCardanoEra C.ShelleyEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, ())) utxoSet)
+  C.InAnyCardanoEra C.AlonzoEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, ())) utxoSet)
+  C.InAnyCardanoEra C.BabbageEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, ())) utxoSet)
+  C.InAnyCardanoEra C.ConwayEra (UTxO utxoSet) -> UtxoSet (fmap (\x -> (C.InAnyCardanoEra C.cardanoEra x, ())) utxoSet)
 
-{-| Convert a utxo set to a @cardano-api@ 'UTxO BabbageEra'
+toApiUtxo :: forall era a. C.IsBabbageBasedEra era => UtxoSet C.CtxUTxO a -> UTxO era
+toApiUtxo (UtxoSet utxos) = UTxO (fmap (toTxOut . fst) utxos)
+
+{-| Convert the tx out to the given era
 -}
-toApiUtxo :: UtxoSet C.CtxUTxO era a -> UTxO era
-toApiUtxo (UtxoSet utxos) =
-  UTxO (fmap fst utxos)
+toTxOut :: forall era. C.IsBabbageBasedEra era => C.InAnyCardanoEra (C.TxOut C.CtxUTxO) -> C.TxOut C.CtxUTxO era
+toTxOut (C.InAnyCardanoEra _era txOut) = utxoToLatestEra @era txOut
+
+-- FIXME (koslambrou) Move to proper package
+txOutToLatestEra :: forall era era1. C.IsBabbageBasedEra era => C.TxOut C.CtxTx era1 -> C.TxOut C.CtxTx era
+txOutToLatestEra (C.TxOut addrInEra txOutValue txOutDatum ref) = inBabbage @era $
+  C.TxOut
+    (convertAddrToLatestEra addrInEra)
+    (C.TxOutValueShelleyBased C.shelleyBasedEra $
+      C.toLedgerValue @era C.maryBasedEra $ C.txOutValueToValue txOutValue)
+    (convertDatumToLatestEra txOutDatum)
+    (convertRefScriptToLatestEra ref)
+ where
+  convertAddrToLatestEra :: C.AddressInEra era1 -> C.AddressInEra era
+  convertAddrToLatestEra (C.AddressInEra C.ByronAddressInAnyEra addr) =
+    C.AddressInEra C.ByronAddressInAnyEra addr
+  convertAddrToLatestEra (C.AddressInEra (C.ShelleyAddressInEra _) addr) = inBabbage @era $
+    C.AddressInEra (C.ShelleyAddressInEra C.shelleyBasedEra) addr
+
+  convertDatumToLatestEra :: C.TxOutDatum C.CtxTx era1 -> C.TxOutDatum C.CtxTx era
+  convertDatumToLatestEra C.TxOutDatumNone = C.TxOutDatumNone
+  convertDatumToLatestEra (C.TxOutDatumHash _ h) = inBabbage @era $ C.TxOutDatumHash C.alonzoBasedEra h
+  convertDatumToLatestEra (C.TxOutDatumInTx _ d) = inBabbage @era $ C.TxOutDatumInTx C.alonzoBasedEra d
+  convertDatumToLatestEra (C.TxOutDatumInline _ d) = C.TxOutDatumInline C.babbageBasedEra d
+
+  convertRefScriptToLatestEra :: CS.ReferenceScript era1 -> CS.ReferenceScript era
+  convertRefScriptToLatestEra CS.ReferenceScriptNone = CS.ReferenceScriptNone
+  convertRefScriptToLatestEra (CS.ReferenceScript _ script) = CS.ReferenceScript CS.babbageBasedEra script
+
+-- FIXME (koslambrou) Move to proper package
+utxoToLatestEra :: forall era era1. C.IsBabbageBasedEra era => C.TxOut C.CtxUTxO era1 -> C.TxOut C.CtxUTxO era
+utxoToLatestEra (C.TxOut addrInEra txOutValue txOutDatum ref) = inBabbage @era $
+  C.TxOut
+    (convertAddrToLatestEra addrInEra)
+    (C.TxOutValueShelleyBased C.shelleyBasedEra $
+      C.toLedgerValue @era C.maryBasedEra $ C.txOutValueToValue txOutValue)
+    (convertDatumToLatestEra txOutDatum)
+    (convertRefScriptToLatestEra ref)
+ where
+  convertAddrToLatestEra :: C.AddressInEra era1 -> C.AddressInEra era
+  convertAddrToLatestEra (C.AddressInEra C.ByronAddressInAnyEra addr) =
+    C.AddressInEra C.ByronAddressInAnyEra addr
+  convertAddrToLatestEra (C.AddressInEra (C.ShelleyAddressInEra _) addr) =
+    inBabbage @era $
+      C.AddressInEra (C.ShelleyAddressInEra C.shelleyBasedEra) addr
+
+  convertDatumToLatestEra :: C.TxOutDatum C.CtxUTxO era1 -> C.TxOutDatum C.CtxUTxO era
+  convertDatumToLatestEra C.TxOutDatumNone = C.TxOutDatumNone
+  convertDatumToLatestEra (C.TxOutDatumHash _ h) = inBabbage @era $ C.TxOutDatumHash C.alonzoBasedEra h
+  convertDatumToLatestEra (C.TxOutDatumInline _ d) = C.TxOutDatumInline C.babbageBasedEra d
+
+  convertRefScriptToLatestEra :: CS.ReferenceScript era1 -> CS.ReferenceScript era
+  convertRefScriptToLatestEra CS.ReferenceScriptNone = CS.ReferenceScriptNone
+  convertRefScriptToLatestEra (CS.ReferenceScript _ script) = CS.ReferenceScript CS.babbageBasedEra script
 
 {-| Pick an unspent output from the 'UtxoSet', if there is one.
 -}
-selectUtxo :: UtxoSet ctx era a -> Maybe (C.TxIn, (C.TxOut ctx era, a))
+selectUtxo :: UtxoSet ctx a -> Maybe (C.TxIn, (C.InAnyCardanoEra (C.TxOut ctx), a))
 selectUtxo =
   -- sorting by key is pretty much a random order
   listToMaybe . Map.toAscList . _utxos
 
 {-| Restrict the 'UtxoSet' to outputs that only have Ada values (no native assets)
 -}
-onlyAda :: UtxoSet ctx era a -> UtxoSet ctx era a
+onlyAda :: UtxoSet ctx a -> UtxoSet ctx a
 onlyAda =
-  let txOutHasOnlyAda :: (C.TxOut ctx era, a) -> Bool
-      txOutHasOnlyAda (txOut, _) =
+  let txOutHasOnlyAda :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
+      txOutHasOnlyAda (C.InAnyCardanoEra _ txOut, _) =
         isJust $ C.valueToLovelace $ C.txOutValueToValue $ view (L._TxOut . _2) txOut
   in fst . partition txOutHasOnlyAda
 
 {-| Partition the UtxoSet according to a predicate. The first UtxoSet contains all
 utxos that satisfy the predicate, the second all utxos that fail the predicate.
 -}
-partition :: ((C.TxOut ctx era, a) -> Bool) -> UtxoSet ctx era a -> (UtxoSet ctx era a, UtxoSet ctx era a)
+partition :: ((C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool) -> UtxoSet ctx a -> (UtxoSet ctx a, UtxoSet ctx a)
 partition p (UtxoSet s) =
   bimap UtxoSet UtxoSet (Map.partition p s)
 
 {-| Restrict the 'UtxoSet' to outputs at the address
 -}
-onlyAddress :: C.AddressAny -> UtxoSet ctx era a -> UtxoSet ctx era a
+onlyAddress :: C.AddressAny -> UtxoSet ctx a -> UtxoSet ctx a
 onlyAddress expectedAddr =
-  let txOutHasAddr :: (C.TxOut ctx era, a) -> Bool
-      txOutHasAddr (C.TxOut addrInEra _ _ _, _) =
+  let txOutHasAddr :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
+      txOutHasAddr (C.InAnyCardanoEra _ (C.TxOut addrInEra _ _ _), _) =
         case addrInEra of
           C.AddressInEra C.ByronAddressInAnyEra addr -> expectedAddr == C.toAddressAny addr
           C.AddressInEra (C.ShelleyAddressInEra _) addr -> expectedAddr == C.toAddressAny addr
@@ -179,29 +329,29 @@ onlyAddress expectedAddr =
 
 {-| Restrict the utxo set to outputs with the given payment credential
 -}
-onlyCredential :: C.PaymentCredential -> UtxoSet ctx era a -> UtxoSet ctx era a
+onlyCredential :: C.PaymentCredential -> UtxoSet ctx a -> UtxoSet ctx a
 onlyCredential c = onlyCredentials (Set.singleton c)
 
 {-| Restrict the utxo set to outputs locked by one of the given payment credentials
 -}
-onlyCredentials :: Set (C.PaymentCredential) -> UtxoSet ctx era a -> UtxoSet ctx era a
+onlyCredentials :: Set C.PaymentCredential -> UtxoSet ctx a -> UtxoSet ctx a
 onlyCredentials cs =
-  let txOutHasOneOfCreds :: (C.TxOut ctx era, a) -> Bool
-      txOutHasOneOfCreds (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _, _) =
+  let txOutHasOneOfCreds :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
+      txOutHasOneOfCreds (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _), _) =
         False
-      txOutHasOneOfCreds (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _, _) =
+      txOutHasOneOfCreds (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _), _) =
         let (CS.ShelleyAddress _ (CS.fromShelleyPaymentCredential -> c) _) = addr
          in c `Set.member` cs
   in fst . partition txOutHasOneOfCreds
 
 {-| Restrict the utxo set to outputs with the given stake credential
 -}
-onlyStakeCredential :: StakeCredential -> UtxoSet ctx era a -> UtxoSet ctx era a
+onlyStakeCredential :: StakeCredential -> UtxoSet ctx a -> UtxoSet ctx a
 onlyStakeCredential expectedStakeCredential =
-  let txOutHasStakeCred :: (C.TxOut ctx era, a) -> Bool
-      txOutHasStakeCred (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _, _) =
+  let txOutHasStakeCred :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
+      txOutHasStakeCred (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _), _) =
         False
-      txOutHasStakeCred (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _, _) =
+      txOutHasStakeCred (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _), _) =
         let (CS.ShelleyAddress _ _ (CS.fromShelleyStakeReference -> stakeRef)) = addr
          in case stakeRef of
               C.StakeAddressByValue stakeCred -> expectedStakeCredential == stakeCred
@@ -211,12 +361,12 @@ onlyStakeCredential expectedStakeCredential =
 
 {-| Restrict the 'UtxoSet' to public key outputs
 -}
-onlyPubKey :: UtxoSet ctx era a -> UtxoSet ctx era a
+onlyPubKey :: UtxoSet ctx a -> UtxoSet ctx a
 onlyPubKey =
-  let txOutHasPubKeyAddr :: (C.TxOut ctx era, a) -> Bool
-      txOutHasPubKeyAddr (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _, _) =
+  let txOutHasPubKeyAddr :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Bool
+      txOutHasPubKeyAddr (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _), _) =
         False
-      txOutHasPubKeyAddr (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _, _) =
+      txOutHasPubKeyAddr (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) _ _ _), _) =
         let (CS.ShelleyAddress _ (CS.fromShelleyPaymentCredential -> cred) _) = addr
          in case cred of
               C.PaymentCredentialByKey _    -> True
@@ -225,79 +375,80 @@ onlyPubKey =
 
 {-| The combined 'Value' of all outputs in the set
 -}
-totalBalance :: UtxoSet ctx era a -> C.Value
+totalBalance :: UtxoSet ctx a -> C.Value
 totalBalance =
-  foldMap (\(C.TxOut _ txOutValue _ _, _) -> C.txOutValueToValue txOutValue) . _utxos
+  foldMap (\(C.InAnyCardanoEra _era (C.TxOut _ txOutValue _ _), _) -> C.txOutValueToValue txOutValue) . _utxos
 
 {-| Delete some outputs from the 'UtxoSet'
 -}
-removeUtxos :: Set.Set C.TxIn -> UtxoSet ctx era a -> UtxoSet ctx era a
+removeUtxos :: Set.Set C.TxIn -> UtxoSet ctx a -> UtxoSet ctx a
 removeUtxos ins = over _UtxoSet (flip Map.withoutKeys ins)
 
 {-| A change to the UTxO set, adding and/or removing UTxOs
 -}
-data UtxoChange ctx era a =
+data UtxoChange ctx a =
   UtxoChange
-    { _outputsAdded   :: !(Map C.TxIn (C.TxOut ctx era, a))
-    , _outputsRemoved :: !(Map C.TxIn (C.TxOut ctx era, a))
+    { _outputsAdded   :: !(Map C.TxIn (C.InAnyCardanoEra (C.TxOut ctx), a))
+    , _outputsRemoved :: !(Map C.TxIn (C.InAnyCardanoEra (C.TxOut ctx), a))
     }
+
 
 {-| Change the context of the outputs in this utxo change
 -}
-toUtxoChangeTx :: UtxoChange C.CtxTx era a -> UtxoChange C.CtxUTxO era a
+toUtxoChangeTx :: UtxoChange C.CtxTx a -> UtxoChange C.CtxUTxO a
 toUtxoChangeTx (UtxoChange added removed) =
-  UtxoChange (fmap (first C.toCtxUTxOTxOut) added) (fmap (first C.toCtxUTxOTxOut) removed)
+  UtxoChange (fmap (first fromTxOutInAnyEraTx) added) (fmap (first fromTxOutInAnyEraTx) removed)
 
 makeLenses ''UtxoChange
 -- TODO: change '<>' so that @x <> invert x == mempty@ and @invert x <> x == mempty@
 
-instance Semigroup (UtxoChange ctx era a) where
+instance Semigroup (UtxoChange ctx a) where
   l <> r =
     UtxoChange
       { _outputsAdded   = _outputsAdded l <> _outputsAdded r
       , _outputsRemoved = _outputsRemoved l <> _outputsRemoved r
       }
 
-instance Monoid (UtxoChange ctx era a) where
+instance Monoid (UtxoChange ctx a) where
   mempty = UtxoChange mempty mempty
 
 {-| Is this the empty 'UtxoChange'?
 -}
-null :: UtxoChange ctx era a -> Bool
+null :: UtxoChange ctx a -> Bool
 null UtxoChange{_outputsAdded, _outputsRemoved} = Map.null _outputsAdded && Map.null _outputsRemoved
 
 {-| An event that caused the utxo set to change
 -}
-type UtxoChangeEvent era a = Either (AddUtxoEvent era a) (RemoveUtxoEvent era a)
+type UtxoChangeEvent a = Either (AddUtxoEvent a) (RemoveUtxoEvent a)
 
 {-| A new tx out was added
 -}
-data AddUtxoEvent era a =
+data AddUtxoEvent a =
   AddUtxoEvent
     { aueEvent :: !a
-    , aueTxOut :: !(C.TxOut C.CtxTx era)
+    , aueTxOut :: !(C.InAnyCardanoEra (C.TxOut C.CtxTx))
     , aueTxIn  :: !TxIn
     , aueTxId  :: !TxId
-    , aueTx    :: !(C.Tx era)
+    , aueTx    :: !(C.InAnyCardanoEra C.Tx)
     }
 
 {-| A tx output was spent
 -}
-data RemoveUtxoEvent era a =
+data RemoveUtxoEvent a =
   RemoveUtxoEvent
     { rueEvent    :: !a
-    , rueTxOut    :: !(C.TxOut C.CtxTx era)
+    , rueTxOut    :: !(C.InAnyCardanoEra (C.TxOut C.CtxTx))
     , rueTxIn     :: !TxIn
     , rueTxId     :: !TxId
     -- ^ Id of the transaction that spent the output
-    , rueTx       :: !(C.Tx era)
+    , rueTx       :: !(C.InAnyCardanoEra C.Tx)
     -- ^ The transaction that spent the output
     , rueRedeemer :: Maybe (HashableScriptData, ExecutionUnits) -- fromAlonzoData
     }
 
 {-| The 'UtxoChange' represented by the event.
 -}
-fromEvent :: UtxoChangeEvent era a -> UtxoChange C.CtxTx era a
+fromEvent :: UtxoChangeEvent a -> UtxoChange C.CtxTx a
 fromEvent = \case
   Left AddUtxoEvent{aueEvent, aueTxOut, aueTxIn} ->
     let ch = Map.singleton aueTxIn (aueTxOut, aueEvent)
@@ -308,7 +459,7 @@ fromEvent = \case
 
 {-| ID of the transaction that caused the event
 -}
-txId :: UtxoChangeEvent era a -> TxId
+txId :: UtxoChangeEvent a -> TxId
 txId = either aueTxId rueTxId
 
 {-| A type capturing the effect a 'UtxoChange' has on the total balance of each address that it touches
@@ -352,11 +503,11 @@ instance Monoid BalanceChanges where
 
 {-| The change in currency affected by the 'UtxoChange' on each address
 -}
-balanceChange :: UtxoChange ctx era a -> BalanceChanges
+balanceChange :: UtxoChange ctx a -> BalanceChanges
 balanceChange UtxoChange{_outputsAdded, _outputsRemoved} =
-  let k :: (C.TxOut ctx era, a) -> Maybe (C.PaymentCredential, C.Value)
-      k (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _, _) = Nothing
-      k (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) txOutValue _ _, _) =
+  let k :: (C.InAnyCardanoEra (C.TxOut ctx), a) -> Maybe (C.PaymentCredential, C.Value)
+      k (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _), _) = Nothing
+      k (C.InAnyCardanoEra _ (C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) addr) txOutValue _ _), _) =
         let (CS.ShelleyAddress _ (CS.fromShelleyPaymentCredential -> cred) _) = addr
          in Just (cred, C.txOutValueToValue txOutValue)
       tv = Map.fromListWith (<>) . mapMaybe (k . snd) . Map.toList
@@ -379,16 +530,16 @@ changeFor cred (BalanceChanges c) = Map.findWithDefault mempty cred c
 
 {-| Describe the UtxoChange
 -}
-describeChange :: UtxoChange ctx era a -> Text
+describeChange :: UtxoChange ctx a -> Text
 describeChange UtxoChange{_outputsAdded, _outputsRemoved} =
   let tshow = Text.pack . show
   in tshow (Map.size _outputsAdded) <> " outputs added, " <> tshow (Map.size _outputsRemoved) <> " outputs removed"
 
-newtype PrettyUtxoChange ctx era a = PrettyUtxoChange (UtxoChange ctx era a)
+newtype PrettyUtxoChange ctx a = PrettyUtxoChange (UtxoChange ctx a)
 
-instance Pretty a => Pretty (PrettyUtxoChange ctx era a) where
+instance Pretty a => Pretty (PrettyUtxoChange ctx a) where
   pretty (PrettyUtxoChange UtxoChange{_outputsAdded, _outputsRemoved}) =
-    let b = foldMap (\((C.TxOut _ txOutValue _ _), _) -> C.txOutValueToValue txOutValue)
+    let b = foldMap (\((C.InAnyCardanoEra _ (C.TxOut _ txOutValue _ _)), _) -> C.txOutValueToValue txOutValue)
         bPlus = b _outputsAdded
         bMinus = C.negateValue (b _outputsRemoved)
     in Prettyprinter.hsep $
@@ -397,9 +548,9 @@ instance Pretty a => Pretty (PrettyUtxoChange ctx era a) where
         , pretty (Map.size _outputsRemoved), "outputs removed."]
         ++ prettyValue (bPlus <> bMinus)
 
-newtype PrettyBalance ctx era a = PrettyBalance (UtxoSet ctx era a)
+newtype PrettyBalance ctx a = PrettyBalance (UtxoSet ctx a)
 
-instance Pretty a => Pretty (PrettyBalance ctx era a) where
+instance Pretty a => Pretty (PrettyBalance ctx a) where
   pretty (PrettyBalance bal) =
     let nOutputs = Map.size (_utxos bal)
     in hang 4 $ vsep
@@ -408,73 +559,81 @@ instance Pretty a => Pretty (PrettyBalance ctx era a) where
 
 {-| Change the 'UtxoSet'
 -}
-apply :: UtxoSet ctx era a -> UtxoChange ctx era a -> UtxoSet ctx era a
+apply :: UtxoSet ctx a -> UtxoChange ctx a -> UtxoSet ctx a
 apply UtxoSet{_utxos} UtxoChange{_outputsAdded, _outputsRemoved} =
   UtxoSet $ (_utxos `Map.union` _outputsAdded) `Map.difference` _outputsRemoved
 
 {-| Invert a 'UtxoChange' value
 -}
-inv :: UtxoChange ctx era a -> UtxoChange ctx era a
+inv :: UtxoChange ctx a -> UtxoChange ctx a
 inv (UtxoChange added removed) = UtxoChange removed added
 
 {-| Extract from a block the UTXO changes at the given address. Returns the
 'UtxoChange' itself and a set of all transactions that affected the change.
 -}
 -- TODO make better polymorphic
-extract :: forall era a. C.IsCardanoEra era => (C.TxIn -> C.TxOut C.CtxTx era -> Maybe a) -> Maybe AddressCredential -> UtxoSet C.CtxTx era a -> Block era -> [UtxoChangeEvent era a]
-extract ex cred state block@(CS.Block _blockHeader txns) = DList.toList $ case C.cardanoEra @era of
-  C.BabbageEra -> extractBabbage ex state cred block
-  C.ConwayEra  -> foldMap (extractConwayTxn' ex state cred) txns
-  _            -> mempty
+extract :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a) -> Maybe AddressCredential -> UtxoSet C.CtxTx a -> BlockInMode -> [UtxoChangeEvent a]
+extract ex cred state = DList.toList . \case
+  -- FIXME (koslambrou) why is this only extracting from babbage?
+  BlockInMode C.BabbageEra block -> extractBabbage ex state cred block
+  BlockInMode C.ConwayEra  block -> extractConway ex state cred block
+  _                              -> mempty
 
 {-| Extract from a block the UTXO changes at the given address
 -}
-extract_ :: C.IsCardanoEra era => AddressCredential -> UtxoSet C.CtxTx era () -> Block era -> UtxoChange C.CtxTx era ()
+extract_ :: AddressCredential -> UtxoSet C.CtxTx () -> BlockInMode -> UtxoChange C.CtxTx ()
 extract_ a b = foldMap fromEvent . extract (\_ -> const $ Just ()) (Just a) b
 
+extractConway
+  :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
+  -> UtxoSet C.CtxTx a
+  -> Maybe AddressCredential
+  -> Block ConwayEra
+  -> DList (UtxoChangeEvent a)
+extractConway ex state cred (CS.Block _blockHeader txns) = foldMap (extractConwayTxn' ex state cred) txns
 
-checkOutput :: (C.TxIn -> C.TxOut C.CtxTx era -> Maybe a) -> TxId -> Maybe AddressCredential -> TxIx -> C.TxOut C.CtxTx era -> Maybe (TxIn, (C.TxOut C.CtxTx era, a))
-checkOutput _ex _txid _cred _ (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _) = Nothing
-checkOutput ex txid cred txIx_ txOut@(C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) (CS.ShelleyAddress _ outputCred _)) _ _ _)
+checkOutput :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a) -> TxId -> Maybe AddressCredential -> TxIx -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe (TxIn, (C.InAnyCardanoEra (C.TxOut C.CtxTx), a))
+checkOutput _ex _txid _cred _ (C.InAnyCardanoEra _era (C.TxOut (C.AddressInEra C.ByronAddressInAnyEra _) _ _ _)) = Nothing
+checkOutput ex txid cred txIx_ (C.InAnyCardanoEra era txOut@(C.TxOut (C.AddressInEra (C.ShelleyAddressInEra _era) (CS.ShelleyAddress _ outputCred _)) _ _ _))
   | isNothing cred || Just outputCred == cred =
       let txi = TxIn txid txIx_
-      in fmap (\a -> (txi, (txOut, a))) (ex txi txOut)
+      in fmap (\a -> (txi, (C.InAnyCardanoEra era txOut, a))) (ex txi $ C.InAnyCardanoEra era txOut)
   | otherwise = Nothing
 
-mkI :: TxId -> Tx era -> (TxIn, (CS.TxOut CS.CtxTx era, a)) -> AddUtxoEvent era a
+mkI :: TxId -> CS.InAnyCardanoEra Tx -> (TxIn, (CS.InAnyCardanoEra (CS.TxOut CS.CtxTx), a)) -> AddUtxoEvent a
 mkI txid tx (aueTxIn, (aueTxOut, aueEvent)) = AddUtxoEvent{aueEvent, aueTxOut, aueTxIn, aueTxId = txid, aueTx = tx}
 
-mkO :: TxId -> Tx era -> (TxIn, ((CS.TxOut CS.CtxTx era, a), Maybe (HashableScriptData, ExecutionUnits))) -> RemoveUtxoEvent era a
+mkO :: TxId -> CS.InAnyCardanoEra Tx -> (TxIn, ((CS.InAnyCardanoEra (CS.TxOut CS.CtxTx), a), Maybe (HashableScriptData, ExecutionUnits))) -> RemoveUtxoEvent a
 mkO txid tx (rueTxIn, ((rueTxOut, rueEvent), rueRedeemer)) = RemoveUtxoEvent{rueEvent, rueTxOut, rueTxIn, rueTxId = txid, rueTx = tx, rueRedeemer}
 
 {-| Extract from a conway-era transaction the UTXO changes at the given address
  -}
 extractConwayTxn
-  :: (C.TxIn -> C.TxOut C.CtxTx ConwayEra -> Maybe a)
+  :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
   -> Maybe AddressCredential
-  -> UtxoSet C.CtxTx ConwayEra a
+  -> UtxoSet C.CtxTx a
   -> C.Tx ConwayEra
-  -> [UtxoChangeEvent ConwayEra a]
+  -> [UtxoChangeEvent a]
 extractConwayTxn ex cred state = DList.toList . extractConwayTxn' ex state cred
 
 extractConwayTxn'
-  :: forall a. (C.TxIn -> C.TxOut C.CtxTx ConwayEra -> Maybe a)
-  -> UtxoSet C.CtxTx ConwayEra a
+  :: forall a. (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
+  -> UtxoSet C.CtxTx a
   -> Maybe AddressCredential
   -> C.Tx ConwayEra
-  -> DList (UtxoChangeEvent ConwayEra a)
+  -> DList (UtxoChangeEvent a)
 extractConwayTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
   let ShelleyTxBody _ txBody' _scripts scriptData _auxiliaryData _ = txBody
       Conway.TxBody.ConwayTxBody{Conway.TxBody.ctbSpendInputs} = txBody'
       txid = C.getTxId txBody
 
-      allOuts = C.fromLedgerTxOuts C.shelleyBasedEra txBody' scriptData
+      allOuts = fmap (C.InAnyCardanoEra C.ConwayEra) $ C.fromLedgerTxOuts C.ShelleyBasedEraConway txBody' scriptData
 
       txReds = case scriptData of
               C.TxBodyScriptData _ _ r -> r
               _                        -> mempty
 
-      checkInput :: (Word32, TxIn) -> Maybe (TxIn, ((C.TxOut C.CtxTx ConwayEra, a), Maybe (HashableScriptData, ExecutionUnits)))
+      checkInput :: (Word32, TxIn) -> Maybe (TxIn, ((C.InAnyCardanoEra (C.TxOut C.CtxTx), a), Maybe (HashableScriptData, ExecutionUnits)))
       checkInput (idx, txIn) = fmap (txIn,) $ do
         o <- Map.lookup txIn _utxos
         let redeemer = fmap (bimap CS.fromAlonzoData CS.fromAlonzoExUnits) (Alonzo.TxWits.lookupRedeemer (Scripts.Conway.ConwaySpending $ Scripts.AsIx idx) txReds)
@@ -482,13 +641,13 @@ extractConwayTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
 
       _outputsAdded =
         DList.fromList
-        $ fmap (Left . mkI txid theTx)
+        $ fmap (Left . mkI txid (C.inAnyCardanoEra C.ConwayEra theTx))
         $ mapMaybe (uncurry (checkOutput ex txid cred))
         $ zip (TxIx <$> [0..]) allOuts
 
       _outputsRemoved =
         DList.fromList
-        $ fmap (Right . mkO txid theTx)
+        $ fmap (Right . mkO txid (C.inAnyCardanoEra C.ConwayEra theTx))
         $ mapMaybe checkInput
         $ zip [0..] -- for redeemer pointers
         $ fmap (uncurry TxIn . bimap CS.fromShelleyTxId txIx . (\(CT.TxIn i n) -> (i, n)))
@@ -497,41 +656,41 @@ extractConwayTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
   in _outputsAdded <> _outputsRemoved
 
 extractBabbage
-  :: (C.TxIn -> C.TxOut C.CtxTx BabbageEra -> Maybe a)
-  -> UtxoSet C.CtxTx BabbageEra a
+  :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
+  -> UtxoSet C.CtxTx a
   -> Maybe AddressCredential
   -> Block BabbageEra
-  -> DList (UtxoChangeEvent BabbageEra a)
+  -> DList (UtxoChangeEvent a)
 extractBabbage ex state cred (CS.Block _blockHeader txns) = foldMap (extractBabbageTxn' ex state cred) txns
 
 {-| Extract from a transaction the UTXO changes at the given address
  -}
 extractBabbageTxn
-  :: (C.TxIn -> C.TxOut C.CtxTx BabbageEra -> Maybe a)
+  :: (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
   -> Maybe AddressCredential
-  -> UtxoSet C.CtxTx BabbageEra a
+  -> UtxoSet C.CtxTx a
   -> C.Tx BabbageEra
-  -> [UtxoChangeEvent BabbageEra a]
+  -> [UtxoChangeEvent a]
 extractBabbageTxn ex cred state = DList.toList . extractBabbageTxn' ex state cred
 
 extractBabbageTxn'
-  :: forall a. (C.TxIn -> C.TxOut C.CtxTx BabbageEra -> Maybe a)
-  -> UtxoSet C.CtxTx BabbageEra a
+  :: forall a. (C.TxIn -> C.InAnyCardanoEra (C.TxOut C.CtxTx) -> Maybe a)
+  -> UtxoSet C.CtxTx a
   -> Maybe AddressCredential
   -> C.Tx BabbageEra
-  -> DList (UtxoChangeEvent BabbageEra a)
+  -> DList (UtxoChangeEvent a)
 extractBabbageTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
   let ShelleyTxBody _ txBody' _scripts scriptData _auxiliaryData _ = txBody
       Babbage.TxBody.BabbageTxBody{Babbage.TxBody.btbInputs} = txBody'
       txid = C.getTxId txBody
 
-      allOuts = C.fromLedgerTxOuts C.shelleyBasedEra txBody' scriptData
+      allOuts = fmap (C.InAnyCardanoEra C.BabbageEra) $ C.fromLedgerTxOuts C.ShelleyBasedEraBabbage txBody' scriptData
 
       txReds = case scriptData of
               C.TxBodyScriptData _ _ r -> unRedeemers r
               _                        -> mempty
 
-      checkInput :: (Word32, TxIn) -> Maybe (TxIn, ((C.TxOut C.CtxTx BabbageEra, a), Maybe (HashableScriptData, ExecutionUnits)))
+      checkInput :: (Word32, TxIn) -> Maybe (TxIn, ((C.InAnyCardanoEra (C.TxOut C.CtxTx), a), Maybe (HashableScriptData, ExecutionUnits)))
       checkInput (idx, txIn) = fmap (txIn,) $ do
         o <- Map.lookup txIn _utxos
         let redeemer = fmap (bimap CS.fromAlonzoData CS.fromAlonzoExUnits) (Map.lookup (Scripts.AlonzoSpending $ Scripts.AsIx idx) txReds)
@@ -539,18 +698,17 @@ extractBabbageTxn' ex UtxoSet{_utxos} cred theTx@(Tx txBody _) =
 
       _outputsAdded =
         DList.fromList
-        $ fmap (Left . mkI txid theTx)
+        $ fmap (Left . mkI txid (C.inAnyCardanoEra C.BabbageEra theTx))
         $ mapMaybe (uncurry (checkOutput ex txid cred))
         $ zip (TxIx <$> [0..]) allOuts
 
       _outputsRemoved =
         DList.fromList
-        $ fmap (Right . mkO txid theTx)
+        $ fmap (Right . mkO txid (C.inAnyCardanoEra C.BabbageEra theTx))
         $ mapMaybe checkInput
         $ zip [0..] -- for redeemer pointers
         $ fmap (uncurry TxIn . bimap CS.fromShelleyTxId txIx . (\(CT.TxIn i n) -> (i, n)))
         $ Set.toList btbInputs
-
   in _outputsAdded <> _outputsRemoved
 
 txIx :: CT.TxIx -> TxIx

--- a/src/base/lib/Convex/Utxos.hs
+++ b/src/base/lib/Convex/Utxos.hs
@@ -14,7 +14,7 @@
 
 -- FIXME (koslambrou) Remove once we have the newtype for 'AnyCardanoEra TxOut'.
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-deprecations #-} -- see https://github.com/j-mueller/sc-tools/issues/213
 {-# LANGUAGE TypeApplications     #-}
 
 module Convex.Utxos(

--- a/src/coin-selection/convex-coin-selection.cabal
+++ b/src/coin-selection/convex-coin-selection.cabal
@@ -90,5 +90,4 @@ test-suite convex-coin-selection-test
     plutus-ledger-api,
     plutus-tx,
     plutus-tx-plugin,
-    mtl,
-    transformers
+    mtl

--- a/src/coin-selection/convex-coin-selection.cabal
+++ b/src/coin-selection/convex-coin-selection.cabal
@@ -47,7 +47,6 @@ library
       convex-optics,
       convex-wallet,
       data-default,
-      primitive,
       servant-client,
       text
 

--- a/src/coin-selection/lib/Convex/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeOperators      #-}
 {-# LANGUAGE ViewPatterns       #-}
+{-# OPTIONS_GHC -Wno-deprecations #-} -- see https://github.com/j-mueller/sc-tools/issues/213
 {-| Building cardano transactions from tx bodies
 -}
 module Convex.CoinSelection(

--- a/src/coin-selection/lib/Convex/CoinSelection/Class.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection/Class.hs
@@ -63,7 +63,7 @@ class Monad m => MonadBalance era m where
     AddressInEra era ->
 
     -- | Set of UTxOs that can be used to supply missing funds
-    UtxoSet C.CtxUTxO era a ->
+    UtxoSet C.CtxUTxO a ->
 
     -- | The unbalanced transaction body
     TxBuilder era ->
@@ -75,7 +75,7 @@ class Monad m => MonadBalance era m where
     m (Either (BalanceTxError era) (C.BalancedTxBody era, BalanceChanges))
 
   default balanceTx :: (MonadTrans t, m ~ t n, MonadBalance era n) =>
-    AddressInEra era -> UtxoSet C.CtxUTxO era a -> TxBuilder era -> ChangeOutputPosition -> m (Either (BalanceTxError era) (C.BalancedTxBody era, BalanceChanges))
+    AddressInEra era -> UtxoSet C.CtxUTxO a -> TxBuilder era -> ChangeOutputPosition -> m (Either (BalanceTxError era) (C.BalancedTxBody era, BalanceChanges))
   balanceTx = (((lift .) .) .) . balanceTx
 
 newtype BalancingT m a = BalancingT{runBalancingT :: m a }
@@ -95,7 +95,7 @@ instance (C.IsBabbageBasedEra era, Convex.Class.MonadBlockchain era m) => MonadB
   balanceTx addr utxos txb changePosition = runExceptT (Convex.CoinSelection.balanceTx mempty (inBabbage @era emptyTxOut addr) utxos txb changePosition)
 
 instance Convex.Class.MonadMockchain era m => Convex.Class.MonadMockchain era (BalancingT m)
-instance Convex.Class.MonadUtxoQuery era m => Convex.Class.MonadUtxoQuery era (BalancingT m)
+instance Convex.Class.MonadUtxoQuery m => Convex.Class.MonadUtxoQuery (BalancingT m)
 
 instance Convex.Class.MonadDatumQuery m => Convex.Class.MonadDatumQuery (BalancingT m) where
   queryDatumFromHash = lift . Convex.Class.queryDatumFromHash
@@ -116,7 +116,7 @@ instance (C.IsBabbageBasedEra era, Convex.Class.MonadBlockchain era m) => MonadB
     runExceptT (Convex.CoinSelection.balanceTx (natTracer (lift . lift) tr) (inBabbage @era emptyTxOut addr) utxos txb changePosition)
 
 instance Convex.Class.MonadMockchain era m => Convex.Class.MonadMockchain era (TracingBalancingT m)
-instance Convex.Class.MonadUtxoQuery era m => Convex.Class.MonadUtxoQuery era (TracingBalancingT m)
+instance Convex.Class.MonadUtxoQuery m => Convex.Class.MonadUtxoQuery (TracingBalancingT m)
 
 instance Convex.Class.MonadDatumQuery m => Convex.Class.MonadDatumQuery (TracingBalancingT m) where
   queryDatumFromHash = lift . Convex.Class.queryDatumFromHash

--- a/src/coin-selection/lib/Convex/CoinSelection/Class.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection/Class.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE DefaultSignatures    #-}
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-| An effect for balancing transactions
 -}
@@ -13,14 +15,13 @@ module Convex.CoinSelection.Class(
   runTracingBalancingT
 ) where
 
-import           Cardano.Api.Shelley              (AddressInEra, ConwayEra)
+import           Cardano.Api.Shelley              (AddressInEra)
 import qualified Cardano.Api.Shelley              as C
 import           Control.Monad.Catch              (MonadCatch, MonadMask,
                                                    MonadThrow)
 import           Control.Monad.Except             (ExceptT, MonadError,
                                                    runExceptT)
 import           Control.Monad.IO.Class           (MonadIO)
-import           Control.Monad.Primitive          (PrimMonad (..))
 import           Control.Monad.Reader             (ReaderT (runReaderT), ask)
 import           Control.Monad.Trans.Class        (MonadTrans (..))
 import qualified Control.Monad.Trans.State        as StrictState
@@ -31,12 +32,13 @@ import           Convex.CardanoApi.Lenses         (emptyTxOut)
 import           Convex.Class                     (MonadBlockchain (..),
                                                    MonadDatumQuery (queryDatumFromHash),
                                                    MonadMockchain (..),
-                                                   MonadUtxoQuery (utxosByPaymentCredentials))
+                                                   MonadUtxoQuery)
 import           Convex.CoinSelection             (BalanceTxError,
                                                    ChangeOutputPosition,
                                                    TxBalancingMessage)
 import qualified Convex.CoinSelection
 import           Convex.MonadLog                  (MonadLog, MonadLogIgnoreT)
+import           Convex.Utils                     (inBabbage)
 import           Convex.Utxos                     (BalanceChanges (..),
                                                    UtxoSet (..))
 
@@ -53,95 +55,71 @@ we do indeed just call 'Convex.CoinSelection.balanceTx', but for
 
 {-| Balancing a transaction
 -}
-class Monad m => MonadBalance m where
+class Monad m => MonadBalance era m where
   {-| Balance the transaction using the given UTXOs and return address.
   -}
   balanceTx ::
     -- | Address used for leftover funds
-    AddressInEra ConwayEra ->
+    AddressInEra era ->
 
     -- | Set of UTxOs that can be used to supply missing funds
-    UtxoSet C.CtxUTxO a ->
+    UtxoSet C.CtxUTxO era a ->
 
     -- | The unbalanced transaction body
-    TxBuilder ->
+    TxBuilder era ->
 
     -- | The position of the change output
     ChangeOutputPosition ->
 
     -- | The balanced transaction body and the balance changes (per address)
-    m (Either (BalanceTxError C.ConwayEra) (C.BalancedTxBody ConwayEra, BalanceChanges))
+    m (Either (BalanceTxError era) (C.BalancedTxBody era, BalanceChanges))
+
+  default balanceTx :: (MonadTrans t, m ~ t n, MonadBalance era n) =>
+    AddressInEra era -> UtxoSet C.CtxUTxO era a -> TxBuilder era -> ChangeOutputPosition -> m (Either (BalanceTxError era) (C.BalancedTxBody era, BalanceChanges))
+  balanceTx = (((lift .) .) .) . balanceTx
 
 newtype BalancingT m a = BalancingT{runBalancingT :: m a }
-  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadCatch, MonadFail, MonadLog, MonadThrow, MonadMask, MonadBlockchain)
-
-instance PrimMonad m => PrimMonad (BalancingT m) where
-  type PrimState (BalancingT m) = PrimState m
-  {-# INLINEABLE primitive #-}
-  primitive f = lift (primitive f)
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadCatch, MonadFail, MonadLog, MonadThrow, MonadMask, Convex.Class.MonadBlockchain era)
 
 instance MonadTrans BalancingT where
   lift = BalancingT
 
 deriving newtype instance MonadError e m => MonadError e (BalancingT m)
 
-instance MonadBalance m => MonadBalance (ExceptT e m) where
-  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
+instance MonadBalance era m => MonadBalance era (ExceptT e m)
+instance MonadBalance era m => MonadBalance era (ReaderT e m)
+instance MonadBalance era m => MonadBalance era (StrictState.StateT s m)
+instance MonadBalance era m => MonadBalance era (LazyState.StateT s m)
+instance MonadBalance era m => MonadBalance era (MonadLogIgnoreT m)
+instance (C.IsBabbageBasedEra era, Convex.Class.MonadBlockchain era m) => MonadBalance era (BalancingT m) where
+  balanceTx addr utxos txb changePosition = runExceptT (Convex.CoinSelection.balanceTx mempty (inBabbage @era emptyTxOut addr) utxos txb changePosition)
 
-instance MonadBalance m => MonadBalance (ReaderT e m) where
-  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
+instance Convex.Class.MonadMockchain era m => Convex.Class.MonadMockchain era (BalancingT m)
+instance Convex.Class.MonadUtxoQuery era m => Convex.Class.MonadUtxoQuery era (BalancingT m)
 
-instance MonadBalance m => MonadBalance (StrictState.StateT s m) where
-  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
-
-instance MonadBalance m => MonadBalance (LazyState.StateT s m) where
-  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
-
-instance MonadBalance m => MonadBalance (MonadLogIgnoreT m) where
-  balanceTx addr utxos txb = lift . balanceTx addr utxos txb
-
-instance (MonadBlockchain m) => MonadBalance (BalancingT m) where
-  balanceTx addr utxos txb changePosition = runExceptT (Convex.CoinSelection.balanceTx mempty (C.InAnyCardanoEra C.ConwayEra $ emptyTxOut addr) utxos txb changePosition)
-
-instance MonadMockchain m => MonadMockchain (BalancingT m) where
-  modifyMockChainState = lift . modifyMockChainState
-  askNodeParams = lift askNodeParams
-
-instance MonadUtxoQuery m => MonadUtxoQuery (BalancingT m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
-
-instance MonadDatumQuery m => MonadDatumQuery (BalancingT m) where
-  queryDatumFromHash = lift . queryDatumFromHash
+instance Convex.Class.MonadDatumQuery m => Convex.Class.MonadDatumQuery (BalancingT m) where
+  queryDatumFromHash = lift . Convex.Class.queryDatumFromHash
 
 {-| Implementation of @MonadBalance@ that uses the provided tracer for debugging output
 -}
 newtype TracingBalancingT m a = TracingBalancingT{ runTracingBalancingT' :: ReaderT (Tracer m TxBalancingMessage) m a }
-  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadCatch, MonadFail, MonadLog, MonadThrow, MonadMask, MonadBlockchain)
-
-instance PrimMonad m => PrimMonad (TracingBalancingT m) where
-  type PrimState (TracingBalancingT m) = PrimState m
-  {-# INLINEABLE primitive #-}
-  primitive f = lift (primitive f)
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadCatch, MonadFail, MonadLog, MonadThrow, MonadMask, Convex.Class.MonadBlockchain era)
 
 instance MonadTrans TracingBalancingT where
   lift = TracingBalancingT . lift
 
 deriving newtype instance MonadError e m => MonadError e (TracingBalancingT m)
 
-instance (MonadBlockchain m) => MonadBalance (TracingBalancingT m) where
+instance (C.IsBabbageBasedEra era, Convex.Class.MonadBlockchain era m) => MonadBalance era (TracingBalancingT m) where
   balanceTx addr utxos txb changePosition = TracingBalancingT $ do
     tr <- ask
-    runExceptT (Convex.CoinSelection.balanceTx (natTracer (lift . lift) tr) (C.InAnyCardanoEra C.ConwayEra $ emptyTxOut addr) utxos txb changePosition)
+    runExceptT (Convex.CoinSelection.balanceTx (natTracer (lift . lift) tr) (inBabbage @era emptyTxOut addr) utxos txb changePosition)
 
-instance MonadMockchain m => MonadMockchain (TracingBalancingT m) where
-  modifyMockChainState = lift . modifyMockChainState
-  askNodeParams = lift askNodeParams
+instance Convex.Class.MonadMockchain era m => Convex.Class.MonadMockchain era (TracingBalancingT m)
+instance Convex.Class.MonadUtxoQuery era m => Convex.Class.MonadUtxoQuery era (TracingBalancingT m)
 
-instance MonadUtxoQuery m => MonadUtxoQuery (TracingBalancingT m) where
-  utxosByPaymentCredentials = lift . utxosByPaymentCredentials
-
-instance MonadDatumQuery m => MonadDatumQuery (TracingBalancingT m) where
-  queryDatumFromHash = lift . queryDatumFromHash
+instance Convex.Class.MonadDatumQuery m => Convex.Class.MonadDatumQuery (TracingBalancingT m) where
+  queryDatumFromHash = lift . Convex.Class.queryDatumFromHash
 
 runTracingBalancingT :: Tracer m TxBalancingMessage -> TracingBalancingT m a -> m a
 runTracingBalancingT tracer (TracingBalancingT action) = runReaderT action tracer

--- a/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
@@ -113,11 +113,11 @@ payToOperator dbg = payToOperator' dbg (C.lovelaceToValue 100_000_000)
 {-| Pay some Ada from one of the seed addresses to an @Operator@
 -}
 payToOperator' :: forall era k m. (MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era) => Tracer m TxBalancingMessage -> Value -> Wallet -> Operator k -> m (Either (ValidationError era) (C.Tx era))
-payToOperator' dbg value wFrom Operator{oPaymentKey} = do
+payToOperator' dbg value wFrom Operator{oPaymentKey} = inBabbage @era $ do
   p <- queryProtocolParameters
   let addr =
-        C.makeShelleyAddressInEra (C.babbageEraOnwardsToShelleyBasedEra C.babbageBasedEra) Defaults.networkId
+        C.makeShelleyAddressInEra @era (C.babbageEraOnwardsToShelleyBasedEra C.babbageBasedEra) Defaults.networkId
         (C.PaymentCredentialByKey $ C.verificationKeyHash $ verificationKey oPaymentKey)
         C.NoStakeAddress
-      tx = execBuildTx (inBabbage @era $ payToAddress addr value >> setMinAdaDepositAll p)
+      tx = execBuildTx (payToAddress @era addr value >> setMinAdaDepositAll p)
   balanceAndSubmit dbg wFrom tx TrailingChange []

--- a/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/MockChain/CoinSelection.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications   #-}
 {-| Conveniences for balancing transactions and selecting coins
 on the mockchain
 -}
 module Convex.MockChain.CoinSelection(
   balanceAndSubmit,
   tryBalanceAndSubmit,
-  SendTxFailed(..),
   balanceAndSubmitReturn,
   paymentTo,
   payToOperator,
@@ -21,13 +21,14 @@ import           Convex.BuildTx            (TxBuilder, execBuildTx,
                                             payToAddress, setMinAdaDepositAll)
 import           Convex.CardanoApi.Lenses  (emptyTxOut)
 import           Convex.Class              (MonadBlockchain (..),
-                                            MonadMockchain, SendTxFailed (..))
+                                            MonadMockchain, ValidationError)
 import           Convex.CoinSelection      (BalanceTxError,
                                             ChangeOutputPosition (TrailingChange),
                                             TxBalancingMessage)
 import qualified Convex.CoinSelection      as CoinSelection
 import qualified Convex.MockChain          as MockChain
 import qualified Convex.MockChain.Defaults as Defaults
+import           Convex.Utils              (inBabbage)
 import           Convex.Wallet             (Wallet)
 import qualified Convex.Wallet             as Wallet
 import           Convex.Wallet.Operator    (Operator (..), verificationKey)
@@ -37,17 +38,18 @@ import           Data.Functor              (($>))
 on the mockchain, using the default network ID
 -}
 balanceAndSubmit ::
-  (MonadMockchain m, MonadError (BalanceTxError CoinSelection.ERA) m) =>
+  forall era m.
+  (MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era) =>
   Tracer m TxBalancingMessage ->
   Wallet ->
-  TxBuilder ->
+  TxBuilder era ->
   ChangeOutputPosition ->
   [C.ShelleyWitnessSigningKey] ->
-  m (Either SendTxFailed (C.Tx CoinSelection.ERA))
-balanceAndSubmit dbg wallet tx changePosition keys = do
+  m (Either (ValidationError era) (C.Tx era))
+balanceAndSubmit dbg wallet tx changePosition keys = inBabbage @era $ do
   n <- queryNetworkId
   let walletAddress = Wallet.addressInEra n wallet
-      txOut = C.InAnyCardanoEra C.ConwayEra $ emptyTxOut walletAddress
+      txOut = emptyTxOut walletAddress
   balanceAndSubmitReturn dbg wallet txOut tx changePosition keys
 
 {-| Balance and submit a transaction using the wallet's UTXOs
@@ -55,38 +57,40 @@ on the mockchain, using the default network ID. Fail if the
 transaction is not accepted by the node.
 -}
 tryBalanceAndSubmit ::
-  (MonadMockchain m, MonadError (BalanceTxError CoinSelection.ERA) m, MonadFail m) =>
+  forall era m.
+  (MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m, C.IsBabbageBasedEra era) =>
   Tracer m TxBalancingMessage ->
   Wallet ->
-  TxBuilder ->
+  TxBuilder era ->
   ChangeOutputPosition ->
   [C.ShelleyWitnessSigningKey] ->
-  m (C.Tx CoinSelection.ERA)
-tryBalanceAndSubmit dbg wallet tx changePosition keys = do
+  m (C.Tx era)
+tryBalanceAndSubmit dbg wallet tx changePosition keys = inBabbage @era $ do
   n <- queryNetworkId
   let walletAddress = Wallet.addressInEra n wallet
-      txOut = C.InAnyCardanoEra C.ConwayEra $ emptyTxOut walletAddress
+      txOut = emptyTxOut walletAddress
   balanceAndSubmitReturn dbg wallet txOut tx changePosition keys >>= either (fail . show) pure
 
 {-| Balance and submit a transaction using the given return output and the wallet's UTXOs
 on the mockchain, using the default network ID
 -}
 balanceAndSubmitReturn ::
-  (MonadMockchain m, MonadError (BalanceTxError CoinSelection.ERA) m) =>
+  forall era m.
+  (MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era) =>
   Tracer m TxBalancingMessage ->
   Wallet ->
-  C.InAnyCardanoEra (C.TxOut C.CtxTx) ->
-  TxBuilder ->
+  C.TxOut C.CtxTx era ->
+  TxBuilder era ->
   ChangeOutputPosition ->
   [C.ShelleyWitnessSigningKey] ->
-  m (Either SendTxFailed (C.Tx CoinSelection.ERA))
-balanceAndSubmitReturn dbg wallet returnOutput tx changePosition keys = do
+  m (Either (ValidationError era) (C.Tx era))
+balanceAndSubmitReturn dbg wallet returnOutput tx changePosition keys = inBabbage @era $ do
   u <- MockChain.walletUtxo wallet
   (tx', _) <- CoinSelection.balanceForWalletReturn dbg wallet u returnOutput tx changePosition
   let
     appendKeys (C.Tx body wit) =
       C.makeSignedTransaction
-        ((C.makeShelleyKeyWitness C.ShelleyBasedEraConway body <$> keys) ++ wit)
+        ((C.makeShelleyKeyWitness C.shelleyBasedEra body <$> keys) ++ wit)
         body
     signedTx = appendKeys tx'
   k <- sendTx signedTx
@@ -94,24 +98,26 @@ balanceAndSubmitReturn dbg wallet returnOutput tx changePosition keys = do
 
 {-| Pay ten Ada from one wallet to another
 -}
-paymentTo :: (MonadMockchain m, MonadError (BalanceTxError CoinSelection.ERA) m) => Wallet -> Wallet -> m (Either SendTxFailed (C.Tx CoinSelection.ERA))
-paymentTo wFrom wTo = do
+paymentTo :: forall era m.
+  (MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era)
+  => Wallet -> Wallet -> m (Either (ValidationError era) (C.Tx era))
+paymentTo wFrom wTo = inBabbage @era $ do
   let tx = execBuildTx (payToAddress (Wallet.addressInEra Defaults.networkId wTo) (C.lovelaceToValue 10_000_000))
   balanceAndSubmit mempty wFrom tx TrailingChange []
 
 {-| Pay 100 Ada from one of the seed addresses to an @Operator@
 -}
-payToOperator :: (MonadMockchain m, MonadError (BalanceTxError CoinSelection.ERA) m) => Tracer m TxBalancingMessage -> Wallet -> Operator k -> m (Either SendTxFailed (C.Tx C.ConwayEra))
-payToOperator dbg wFrom = payToOperator' dbg (C.lovelaceToValue 100_000_000) wFrom
+payToOperator :: (MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era) => Tracer m TxBalancingMessage -> Wallet -> Operator k -> m (Either (ValidationError era) (C.Tx era))
+payToOperator dbg = payToOperator' dbg (C.lovelaceToValue 100_000_000)
 
 {-| Pay some Ada from one of the seed addresses to an @Operator@
 -}
-payToOperator' :: (MonadMockchain m, MonadError (BalanceTxError CoinSelection.ERA) m) => Tracer m TxBalancingMessage -> Value -> Wallet -> Operator k -> m (Either SendTxFailed (C.Tx C.ConwayEra))
+payToOperator' :: forall era k m. (MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era) => Tracer m TxBalancingMessage -> Value -> Wallet -> Operator k -> m (Either (ValidationError era) (C.Tx era))
 payToOperator' dbg value wFrom Operator{oPaymentKey} = do
   p <- queryProtocolParameters
   let addr =
-        C.makeShelleyAddressInEra C.ShelleyBasedEraConway Defaults.networkId
+        C.makeShelleyAddressInEra (C.babbageEraOnwardsToShelleyBasedEra C.babbageBasedEra) Defaults.networkId
         (C.PaymentCredentialByKey $ C.verificationKeyHash $ verificationKey oPaymentKey)
         C.NoStakeAddress
-      tx = execBuildTx (payToAddress addr value >> setMinAdaDepositAll p)
+      tx = execBuildTx (inBabbage @era $ payToAddress addr value >> setMinAdaDepositAll p)
   balanceAndSubmit dbg wFrom tx TrailingChange []

--- a/src/coin-selection/lib/Convex/Query.hs
+++ b/src/coin-selection/lib/Convex/Query.hs
@@ -107,8 +107,8 @@ balancePaymentCredentials ::
   m (C.Tx era)
 balancePaymentCredentials dbg primaryCred otherCreds returnOutput txBody changePosition = do
   output <- maybe (inBabbage @era returnOutputFor primaryCred) pure returnOutput
-  (C.BalancedTxBody _ txbody _changeOutput _fee, _) <- liftEither BalanceError (balanceTx dbg (primaryCred:otherCreds) output txBody changePosition)
-  pure (C.makeSignedTransaction [] txbody)
+  (body, _) <- liftEither BalanceError (balanceTx dbg (primaryCred:otherCreds) output txBody changePosition)
+  pure $ Convex.CoinSelection.signBalancedTxBody [] body
 
 {-| Balance a transaction body using the funds locked by the payment credential
 -}

--- a/src/coin-selection/test/Scripts.hs
+++ b/src/coin-selection/test/Scripts.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:target-version=1.0.0 #-} -- 1.1.0.0 will be enabled in conway
+{-# OPTIONS_GHC -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:target-version=1.1.0.0 #-} -- 1.1.0.0 will be enabled in conway
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE PackageImports   #-}
 {-# LANGUAGE TemplateHaskell  #-}

--- a/src/coin-selection/test/Scripts.hs
+++ b/src/coin-selection/test/Scripts.hs
@@ -54,9 +54,9 @@ matchingIndexMPScript = compiledCodeToScript matchingIndexMPCompiled
 {-| Spend an output locked by 'matchingIndexValidatorScript', setting
 the redeemer to the index of the input in the final transaction
 -}
-spendMatchingIndex :: MonadBuildTx m => TxIn -> m ()
+spendMatchingIndex :: forall era m. (C.IsAlonzoBasedEra era, C.HasScriptLanguageInEra C.PlutusScriptV2 era) => MonadBuildTx era m => TxIn -> m ()
 spendMatchingIndex txi =
-  let witness txBody = C.ScriptWitness C.ScriptWitnessForSpending $ BuildTx.buildV2ScriptWitness
+  let witness txBody = C.ScriptWitness C.ScriptWitnessForSpending $ BuildTx.buildScriptWitness
         matchingIndexValidatorScript
         (C.ScriptDatumForTxIn $ Just $ toHashableScriptData ())
         (fromIntegral @Int @Integer $ BuildTx.findIndexSpending txi txBody)
@@ -65,10 +65,10 @@ spendMatchingIndex txi =
 {-| Mint a token from the 'matchingIndexMPScript', setting
 the redeemer to the index of its currency symbol in the final transaction mint
 -}
-mintMatchingIndex :: MonadBuildTx m => C.PolicyId -> C.AssetName -> C.Quantity -> m ()
+mintMatchingIndex :: forall era m. (C.IsMaryBasedEra era, C.IsAlonzoBasedEra era, C.HasScriptLanguageInEra C.PlutusScriptV2 era) => MonadBuildTx era m => C.PolicyId -> C.AssetName -> C.Quantity -> m ()
 mintMatchingIndex policy assetName quantity =
-  let witness txBody = BuildTx.buildV2ScriptWitness
+  let witness txBody = BuildTx.buildScriptWitness
         matchingIndexMPScript
-        (C.NoScriptDatumForMint)
+        C.NoScriptDatumForMint
         (fromIntegral @Int @Integer $ BuildTx.findIndexMinted policy txBody)
   in BuildTx.setScriptsValid >> BuildTx.addMintWithTxBody policy assetName quantity witness

--- a/src/coin-selection/test/Spec.hs
+++ b/src/coin-selection/test/Spec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE ViewPatterns       #-}
 module Main(main) where
 
@@ -47,11 +48,13 @@ import qualified Convex.MockChain.Defaults      as Defaults
 import qualified Convex.MockChain.Gen           as Gen
 import           Convex.MockChain.Staking       (registerPool)
 import           Convex.MockChain.Utils         (mockchainSucceeds,
-                                                 runMockchainProp)
+                                                 runMockchainProp,
+                                                 runMockchainPropErr)
 import           Convex.NodeParams              (ledgerProtocolParameters,
                                                  protocolParameters)
 import           Convex.Query                   (balancePaymentCredentials)
-import           Convex.Utils                   (failOnError)
+import           Convex.Utils                   (failOnError, inBabbage,
+                                                 inConway)
 import qualified Convex.Utxos                   as Utxos
 import           Convex.Wallet                  (Wallet)
 import qualified Convex.Wallet                  as Wallet
@@ -128,28 +131,28 @@ txInscript = C.examplePlutusScriptAlwaysSucceeds C.WitCtxTxIn
 mintingScript :: C.PlutusScript C.PlutusScriptV1
 mintingScript = C.examplePlutusScriptAlwaysSucceeds C.WitCtxMint
 
-plutusScript :: C.PlutusScript lang -> C.Script lang
+plutusScript :: C.IsPlutusScriptLanguage lang => C.PlutusScript lang -> C.Script lang
 plutusScript = C.PlutusScript C.plutusScriptVersion
 
-payToPlutusScript :: (MonadFail m, MonadError (BalanceTxError era) m, MonadMockchain era m) => m C.TxIn
-payToPlutusScript = do
+payToPlutusScript :: forall era m. (MonadFail m, MonadError (BalanceTxError era) m, MonadMockchain era m, C.IsBabbageBasedEra era) => m C.TxIn
+payToPlutusScript = inBabbage @era $ do
   let tx = execBuildTx (payToScriptDatumHash Defaults.networkId (plutusScript txInscript) () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
   i <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
   pure (C.TxIn i (C.TxIx 0))
 
-payToPlutusV2Script :: (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m) => m C.TxIn
-payToPlutusV2Script = do
+payToPlutusV2Script :: forall era m. (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era) => m C.TxIn
+payToPlutusV2Script = inBabbage @era $ do
   let tx = execBuildTx (payToScriptDatumHash Defaults.networkId (plutusScript Scripts.v2SpendingScript) () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
   i <- C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
   pure (C.TxIn i (C.TxIx 0))
 
-spendPlutusScript :: (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m) => C.TxIn -> m C.TxId
-spendPlutusScript ref = do
+spendPlutusScript :: forall era m. (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra C.PlutusScriptV1 era) => C.TxIn -> m C.TxId
+spendPlutusScript ref = inBabbage @era $ do
   let tx = execBuildTx (spendPlutus ref txInscript () ())
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
 
-spendPlutusV2Script :: (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m) => C.TxIn -> m C.TxId
-spendPlutusV2Script ref = do
+spendPlutusV2Script :: forall era m. (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra C.PlutusScriptV2 era) => C.TxIn -> m C.TxId
+spendPlutusV2Script ref = inBabbage @era $ do
   let tx = execBuildTx (spendPlutus ref Scripts.v2SpendingScript () ())
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
 
@@ -175,13 +178,13 @@ spendPlutusScriptReference txIn = do
   let tx = execBuildTx (spendPlutusRef txIn refTxIn C.PlutusScriptV2 () ())
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
 
-mintingPlutus :: (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m) => m C.TxId
-mintingPlutus = do
+mintingPlutus :: forall era m. (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra C.PlutusScriptV1 era) => m C.TxId
+mintingPlutus = inBabbage @era $ do
   void $ Wallet.w2 `paymentTo` Wallet.w1
   let tx = execBuildTx (mintPlutus mintingScript () "assetName" 100)
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 tx TrailingChange []
 
-spendTokens :: (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m) => C.TxId -> m C.TxId
+spendTokens :: (MonadFail m, MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m) => C.TxId -> m C.TxId
 spendTokens _ = do
   _ <- nativeAssetPaymentTo 49 Wallet.w1 Wallet.w2
   _ <- nativeAssetPaymentTo 51 Wallet.w1 Wallet.w2
@@ -204,21 +207,21 @@ spendTokens2 txi = do
 
 -- | Put all of the Wallet 2's funds into a single UTxO with mixed assets
 --   Then make a transaction that splits this output into two
-spendSingletonOutput :: (MonadFail m, MonadMockchain era m, MonadError (BalanceTxError era) m) => C.TxId -> m ()
+spendSingletonOutput :: (MonadFail m, MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m) => C.TxId -> m ()
 spendSingletonOutput txi = do
   void (nativeAssetPaymentTo 49 Wallet.w1 Wallet.w2 >> Wallet.w1 `paymentTo` Wallet.w2)
-  utxoSet <- Utxos.fromApiUtxo () . C.fromLedgerUTxO _ <$> getUtxo
+  utxoSet <- Utxos.fromApiUtxo () . fromLedgerUTxO C.shelleyBasedEra <$> getUtxo
   let k = Utxos.onlyCredential (Wallet.paymentCredential Wallet.w2) utxoSet
   let totalVal = Utxos.totalBalance k
-      newOut = C.TxOut (Wallet.addressInEra Defaults.networkId Wallet.w2) (C.TxOutValueShelleyBased C.shelleyBasedEra $ C.toMaryValue totalVal) C.TxOutDatumNone C.ReferenceScriptNone
+      newOut = C.TxOut (Wallet.addressInEra Defaults.networkId Wallet.w2) (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue totalVal) C.TxOutDatumNone C.ReferenceScriptNone
       utxoSetMinusW2 = Utxos.removeUtxos (Map.keysSet $ Utxos._utxos k) utxoSet
-      utxoSetPlusSingleOutput = utxoSetMinusW2 <> Utxos.singleton (C.TxIn txi $ C.TxIx 1000) (C.InAnyCardanoEra C.cardanoEra newOut, ())
+      utxoSetPlusSingleOutput = utxoSetMinusW2 <> Utxos.singleton (C.TxIn txi $ C.TxIx 1000) (newOut, ())
 
   setUtxo (C.toLedgerUTxO C.shelleyBasedEra $ Utxos.toApiUtxo utxoSetPlusSingleOutput)
   -- check that wallet 2 only
   void $ nativeAssetPaymentTo 49 Wallet.w1 Wallet.w2
 
-nativeAssetPaymentTo :: (MonadMockchain era m, MonadFail m, MonadError (BalanceTxError era) m) => C.Quantity -> Wallet -> Wallet -> m C.TxId
+nativeAssetPaymentTo :: (MonadMockchain C.ConwayEra m, MonadFail m, MonadError (BalanceTxError C.ConwayEra) m) => C.Quantity -> Wallet -> Wallet -> m C.TxId
 nativeAssetPaymentTo q wFrom wTo = do
   let vl = assetValue (C.hashScript $ C.PlutusScript C.PlutusScriptV1 mintingScript) "assetName" q
       tx = execBuildTx $
@@ -229,7 +232,7 @@ nativeAssetPaymentTo q wFrom wTo = do
   void $ wTo `paymentTo` wFrom
   C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty wFrom tx TrailingChange []
 
-checkResolveDatumHash :: (MonadMockchain era m, MonadDatumQuery m, MonadFail m, MonadError (BalanceTxError era) m) => m ()
+checkResolveDatumHash :: (MonadMockchain C.ConwayEra m, MonadDatumQuery m, MonadFail m, MonadError (BalanceTxError C.ConwayEra) m) => m ()
 checkResolveDatumHash = do
   let addr = Wallet.addressInEra Defaults.networkId Wallet.w1
       assertDatumPresent vl = queryDatumFromHash (C.hashScriptDataBytes vl) >>= \case
@@ -241,7 +244,7 @@ checkResolveDatumHash = do
 
   -- 1. resolve an inline datum
   let datum1 = C.unsafeHashableScriptData  (C.ScriptDataConstructor 5 [])
-      dat = C.TxOutDatumInline C.BabbageEraOnwardsConway datum1
+      dat = C.TxOutDatumInline C.babbageBasedEra datum1
       txOut = payToAddressTxOut addr mempty
                 & L._TxOut . _3 .~ dat
 
@@ -252,7 +255,7 @@ checkResolveDatumHash = do
   -- 2. resolve a datum that was provided as a "TxOutDatumInTx" (this is what 'payToScriptDatumHash' does)
   let d2 = (11 :: Integer, 12 :: Integer)
       datum2 = C.unsafeHashableScriptData $ C.fromPlutusData $ PV2.toData d2
-  _ <- tryExecBuildTxWallet Wallet.w1 (payToScriptDatumHash Defaults.networkId txInscript d2 C.NoStakeAddress mempty)
+  _ <- tryExecBuildTxWallet Wallet.w1 (payToScriptDatumHash Defaults.networkId (plutusScript txInscript) d2 C.NoStakeAddress mempty)
   assertDatumPresent datum2
 
   -- 3. resolve a datum that was provided by a redeeming transaction
@@ -260,9 +263,9 @@ checkResolveDatumHash = do
       datum3 = C.unsafeHashableScriptData $ C.fromPlutusData $ PV2.toData d3
       txo =
         C.TxOut
-          (C.makeShelleyAddressInEra C.ShelleyBasedEraConway Defaults.networkId (C.PaymentCredentialByScript (C.hashScript (C.PlutusScript C.PlutusScriptV1 txInscript))) C.NoStakeAddress)
-          (C.TxOutValueShelleyBased C.ShelleyBasedEraConway mempty)
-          (C.TxOutDatumHash C.AlonzoEraOnwardsConway (C.hashScriptDataBytes datum3))
+          (C.makeShelleyAddressInEra C.shelleyBasedEra Defaults.networkId (C.PaymentCredentialByScript (C.hashScript (C.PlutusScript C.PlutusScriptV1 txInscript))) C.NoStakeAddress)
+          (C.TxOutValueShelleyBased C.shelleyBasedEra mempty)
+          (C.TxOutDatumHash (C.babbageEraOnwardsToAlonzoEraOnwards C.babbageBasedEra) (C.hashScriptDataBytes datum3))
           C.ReferenceScriptNone
   txId <- tryExecBuildTxWallet Wallet.w1 (prependTxOut txo)
   _ <- tryExecBuildTxWallet Wallet.w1 (spendPlutus (C.TxIn txId (C.TxIx 0)) txInscript d3 ())
@@ -271,7 +274,7 @@ checkResolveDatumHash = do
 {-| Build a transaction, then balance and sign it with the wallet, then
   submit it to the mockchain.
 -}
-execBuildTxWallet :: (MonadMockchain era m, MonadError (BalanceTxError era) m) => Wallet -> BuildTxT m a -> m (Either _ C.TxId)
+execBuildTxWallet :: (MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m) => Wallet -> BuildTxT C.ConwayEra m a -> m (Either (ValidationError C.ConwayEra) C.TxId)
 execBuildTxWallet wallet action = do
   tx <- execBuildTxT (action >> setMinAdaDepositAll Defaults.bundledProtocolParameters)
   fmap (C.getTxId . C.getTxBody) <$> balanceAndSubmit mempty wallet tx TrailingChange []
@@ -279,7 +282,7 @@ execBuildTxWallet wallet action = do
 {-| Build a transaction, then balance and sign it with the wallet, then
   submit it to the mockchain. Fail if 'balanceAndSubmit' is not successful.
 -}
-tryExecBuildTxWallet :: (MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m) => Wallet -> BuildTxT era m a -> m C.TxId
+tryExecBuildTxWallet :: (MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m, MonadFail m) => Wallet -> BuildTxT C.ConwayEra m a -> m C.TxId
 tryExecBuildTxWallet wallet action = execBuildTxWallet wallet action >>= either (fail . show) pure
 
 -- | Balance a transaction using a list of operators
@@ -292,12 +295,12 @@ balanceMultiAddress = do
     QC.forAll (Gen.chooseInteger (7_500_000, 100_000_00 * fromIntegral (1 + length operators))) $ \(C.Quantity -> nAmount) ->
       QC.forAll (Gen.sublistOf (op:operators)) $ \requiredSignatures ->
         classify (null operators) "1 operator"
-          $ classify (length operators > 0 && length operators <= 9) "2-9 operators"
+          $ classify (not (null operators) && length operators <= 9) "2-9 operators"
           $ classify (length operators > 9) "10+ operators"
-          $ classify (length requiredSignatures == 0) "0 required signatures"
-          $ classify (length requiredSignatures > 0 && length requiredSignatures <= 9) "1-9 required signatures"
+          $ classify (null requiredSignatures) "0 required signatures"
+          $ classify (not (null requiredSignatures) && length requiredSignatures <= 9) "1-9 required signatures"
           $ classify (length requiredSignatures > 9) "10+ required signatures"
-          $ runMockchainProp $ lift $ failOnError $ do
+          $ runMockchainPropErr @(BalanceTxError C.ConwayEra) $ do
               -- send Ada to each operator
               traverse_ (payToOperator' mempty (C.lovelaceToValue $ 7_500_000 + C.quantityToLovelace nAmount) Wallet.w2) (op:operators)
 
@@ -323,9 +326,9 @@ buildTxMixedInputs :: Assertion
 buildTxMixedInputs = mockchainSucceeds $ failOnError $ do
   testWallet <- liftIO Wallet.generateWallet
   -- configure the UTxO set to that the new wallet has two outputs, each with 40 native tokens and 10 Ada.
-  utxoSet <- Utxos.fromApiUtxo () . C.inAnyCardanoEra C.cardanoEra . fromLedgerUTxO C.ShelleyBasedEraConway <$> getUtxo
+  utxoSet <- Utxos.fromApiUtxo () . fromLedgerUTxO C.ShelleyBasedEraConway <$> getUtxo
   let utxoVal = assetValue (C.hashScript $ C.PlutusScript C.PlutusScriptV1 mintingScript) "assetName" 40 <> C.lovelaceToValue 10_000_000
-      newUTxO = C.InAnyCardanoEra C.cardanoEra $ C.TxOut (Wallet.addressInEra Defaults.networkId testWallet) (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue utxoVal) C.TxOutDatumNone C.ReferenceScriptNone
+      newUTxO = C.TxOut (Wallet.addressInEra Defaults.networkId testWallet) (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue utxoVal) C.TxOutDatumNone C.ReferenceScriptNone
       txi :: C.TxId = "771dfef6ad6f1fc51eb399c07ff89257b06ba9822aec8f83d89012f04eb738f2"
   setUtxo
     $ C.toLedgerUTxO C.ShelleyBasedEraConway
@@ -345,27 +348,23 @@ buildTxMixedInputs = mockchainSucceeds $ failOnError $ do
 largeTransactionTest :: Assertion
 largeTransactionTest = do
   let largeDatum :: [Integer] = replicate 10_000 33
-      largeDatumTx = execBuildTxWallet Wallet.w1 (payToScriptDatumHash Defaults.networkId txInscript largeDatum C.NoStakeAddress mempty)
+      largeDatumTx = execBuildTxWallet Wallet.w1 (payToScriptDatumHash Defaults.networkId (plutusScript txInscript) largeDatum C.NoStakeAddress mempty)
 
   -- tx fails with default parameters
   runMockchain0IOWith Wallet.initialUTxOs Defaults.nodeParams (failOnError largeDatumTx) >>= \case
-    Right (Left{}, view failedTransactions -> [(_, err)]) -> case err of
+    (_, view failedTransactions -> [(_, err)]) -> case err of
       ApplyTxFailure (ApplyTxError (Rules.ConwayUtxowFailure (Rules.UtxoFailure (Rules.MaxTxSizeUTxO 20313 16384)):|[])) -> pure ()
       _ -> fail $ "Unexpected failure. Expected 'MaxTxSizeUTxO', found " <> show err
-    Right _ -> fail $ "Unexpected success. Expected 1 failed transaction."
-    Left err -> fail $ "Unexpected failure: " <> show err
 
   -- the tx should succeed after setting the max tx size to exactly 20304 (see the error message in the test above)
   let params' = Defaults.nodeParams & ledgerProtocolParameters . protocolParameters . Ledger.ppMaxTxSizeL .~ 20313
   runMockchain0IOWith Wallet.initialUTxOs params' (failOnError largeDatumTx) >>= \case
-    Right (Right{}, view failedTransactions -> []) -> pure ()
-    Right _ -> fail $ "Unexpected failure. Expected 1 successful transaction."
-    Left err -> fail $ "Unexpected failure: " <> show err
+    (Right{}, view failedTransactions -> []) -> pure ()
 
-matchingIndex :: (MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m) => m ()
-matchingIndex = do
-  let txBody = execBuildTx (payToPlutusV2 Defaults.networkId Scripts.matchingIndexValidatorScript () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
-      tx     = C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange []) <*> pure (C.TxIx 0)
+matchingIndex :: forall era m. (MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra C.PlutusScriptV2 era) => m ()
+matchingIndex = inBabbage @era $ do
+  let txBody = execBuildTx (BuildTx.payToScriptDatumHash Defaults.networkId (plutusScript Scripts.matchingIndexValidatorScript) () C.NoStakeAddress (C.lovelaceToValue 10_000_000))
+      tx     = C.TxIn . C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange [] <*> pure (C.TxIx 0)
 
   -- create three separate tx outputs that are locked by the matching index script
   inputs <- replicateM 3 tx
@@ -376,27 +375,27 @@ matchingIndex = do
 stakingCredential :: C.StakeCredential
 stakingCredential = C.StakeCredentialByScript $ C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.v2StakingScript)
 
-registerStakingCredential :: (MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m) => m C.TxIn
-registerStakingCredential = do
+registerStakingCredential :: forall era m. (MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m, C.IsConwayBasedEra era) => m C.TxIn
+registerStakingCredential = inConway @era $ do
   let txBody = execBuildTx (BuildTx.addStakeCredentialCertificate stakingCredential)
-  C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange []) <*> pure (C.TxIx 0)
+  C.TxIn . C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange [] <*> pure (C.TxIx 0)
 
-withdrawZero :: (MonadIO m, MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m) => m ()
-withdrawZero = do
-  txBody <- execBuildTxT (BuildTx.addWithdrawZeroPlutusV2InTransaction Scripts.v2StakingScript ())
-  txI <- C.TxIn <$> (C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange []) <*> pure (C.TxIx 0)
+withdrawZero :: forall era m. (MonadIO m, MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra C.PlutusScriptV2 era) => m ()
+withdrawZero = inBabbage @era $ do
+  txBody <- execBuildTxT (BuildTx.addWithdrawZeroPlutusV2InTransaction Defaults.networkId Scripts.v2StakingScript ())
+  txI <- C.TxIn . C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange [] <*> pure (C.TxIx 0)
   singleUTxO txI >>= \case
     Nothing -> fail "txI not found"
     Just{} -> pure ()
 
-matchingIndexMP ::  (MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m) => m ()
+matchingIndexMP :: forall m. (MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m, MonadFail m) => m ()
 matchingIndexMP = do
   let sh = C.hashScript (C.PlutusScript C.PlutusScriptV2 Scripts.matchingIndexMPScript)
       policyId = C.PolicyId sh
       runTx assetName = Scripts.mintMatchingIndex policyId assetName 100
   void $ tryBalanceAndSubmit mempty Wallet.w1 (execBuildTx $ traverse_ runTx ["assetName1", "assetName2", "assetName3"]) TrailingChange []
 
-queryStakeAddressesTest :: forall era m. (MonadIO m, MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m) => m ()
+queryStakeAddressesTest :: forall era m. (MonadIO m, MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m, MonadFail m) => m ()
 queryStakeAddressesTest = do
   poolId <- registerPool Wallet.w1
   stakeKey <- C.generateSigningKey C.AsStakeKey
@@ -436,7 +435,7 @@ queryStakeAddressesTest = do
   when (length rewards /= 1) $ fail "Expected 1 reward"
   when (length delegations /= 1) $ fail "Expected 1 delegation"
 
-withdrawalTest :: forall era m. (MonadIO m, MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m) => m ()
+withdrawalTest :: forall era m. (MonadIO m, MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m, MonadFail m) => m ()
 withdrawalTest = do
   poolId <- registerPool Wallet.w1
   stakeKey <- C.generateSigningKey C.AsStakeKey

--- a/src/coin-selection/test/Spec.hs
+++ b/src/coin-selection/test/Spec.hs
@@ -208,7 +208,7 @@ spendTokens2 txi = do
 spendSingletonOutput :: (MonadFail m, MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m) => C.TxId -> m ()
 spendSingletonOutput txi = do
   void (nativeAssetPaymentTo 49 Wallet.w1 Wallet.w2 >> Wallet.w1 `paymentTo` Wallet.w2)
-  utxoSet <- Utxos.fromApiUtxo () . fromLedgerUTxO C.shelleyBasedEra <$> getUtxo
+  utxoSet <- Utxos.fromApiUtxo . fromLedgerUTxO C.shelleyBasedEra <$> getUtxo
   let k = Utxos.onlyCredential (Wallet.paymentCredential Wallet.w2) utxoSet
   let totalVal = Utxos.totalBalance k
       newOut = C.TxOut (Wallet.addressInEra Defaults.networkId Wallet.w2) (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue totalVal) C.TxOutDatumNone C.ReferenceScriptNone
@@ -324,7 +324,7 @@ buildTxMixedInputs :: Assertion
 buildTxMixedInputs = mockchainSucceeds $ failOnError $ do
   testWallet <- liftIO Wallet.generateWallet
   -- configure the UTxO set to that the new wallet has two outputs, each with 40 native tokens and 10 Ada.
-  utxoSet <- Utxos.fromApiUtxo () . fromLedgerUTxO C.ShelleyBasedEraConway <$> getUtxo
+  utxoSet <- Utxos.fromApiUtxo . fromLedgerUTxO C.ShelleyBasedEraConway <$> getUtxo
   let utxoVal = assetValue (C.hashScript $ C.PlutusScript C.PlutusScriptV1 mintingScript) "assetName" 40 <> C.lovelaceToValue 10_000_000
       newUTxO = C.TxOut (Wallet.addressInEra Defaults.networkId testWallet) (C.TxOutValueShelleyBased C.ShelleyBasedEraConway $ C.toMaryValue utxoVal) C.TxOutDatumNone C.ReferenceScriptNone
       txi :: C.TxId = "771dfef6ad6f1fc51eb399c07ff89257b06ba9822aec8f83d89012f04eb738f2"
@@ -351,12 +351,12 @@ largeTransactionTest = do
   -- tx fails with default parameters
   runMockchain0IOWith Wallet.initialUTxOs Defaults.nodeParams (failOnError largeDatumTx) >>= \case
     (_, view failedTransactions -> [(_, err)]) -> case err of
-      ApplyTxFailure (ApplyTxError (Rules.ConwayUtxowFailure (Rules.UtxoFailure (Rules.MaxTxSizeUTxO 20313 16384)):|[])) -> pure ()
+      ApplyTxFailure (ApplyTxError (Rules.ConwayUtxowFailure (Rules.UtxoFailure (Rules.MaxTxSizeUTxO 20_313 16384)):|[])) -> pure ()
       _ -> fail $ "Unexpected failure. Expected 'MaxTxSizeUTxO', found " <> show err
     (_, length . view failedTransactions -> numFailed) -> fail $ "Expected one failed transaction, found " <> show numFailed
 
-  -- the tx should succeed after setting the max tx size to exactly 20304 (see the error message in the test above)
-  let params' = Defaults.nodeParams & ledgerProtocolParameters . protocolParameters . Ledger.ppMaxTxSizeL .~ 20313
+  -- the tx should succeed after setting the max tx size to exactly 20313 (see the error message in the test above)
+  let params' = Defaults.nodeParams & ledgerProtocolParameters . protocolParameters . Ledger.ppMaxTxSizeL .~ 20_313
   runMockchain0IOWith Wallet.initialUTxOs params' (failOnError largeDatumTx) >>= \case
     (Right{}, view failedTransactions -> []) -> pure ()
     (_, length . view failedTransactions -> numFailed) -> fail $ "Expected success with 0 failed transactions, found " <> show numFailed

--- a/src/coin-selection/test/Spec.hs
+++ b/src/coin-selection/test/Spec.hs
@@ -382,7 +382,7 @@ registerStakingCredential = inConway @era $ do
 
 withdrawZero :: forall era m. (MonadIO m, MonadMockchain era m, MonadError (BalanceTxError era) m, MonadFail m, C.IsBabbageBasedEra era, C.HasScriptLanguageInEra C.PlutusScriptV2 era) => m ()
 withdrawZero = inBabbage @era $ do
-  txBody <- execBuildTxT (BuildTx.addWithdrawZeroPlutusV2InTransaction Defaults.networkId Scripts.v2StakingScript ())
+  txBody <- execBuildTxT (BuildTx.addWithdrawZeroPlutusV2InTransaction Scripts.v2StakingScript ())
   txI <- C.TxIn . C.getTxId . C.getTxBody <$> tryBalanceAndSubmit mempty Wallet.w1 txBody TrailingChange [] <*> pure (C.TxIx 0)
   singleUTxO txI >>= \case
     Nothing -> fail "txI not found"

--- a/src/coin-selection/test/Spec.hs
+++ b/src/coin-selection/test/Spec.hs
@@ -46,7 +46,8 @@ import qualified Convex.MockChain.Defaults      as Defaults
 import qualified Convex.MockChain.Gen           as Gen
 import           Convex.MockChain.Staking       (registerPool)
 import           Convex.MockChain.Utils         (mockchainSucceeds,
-                                                 runMockchainPropErr)
+                                                 runMockchainProp,
+                                                 runTestableErr)
 import           Convex.NodeParams              (ledgerProtocolParameters,
                                                  protocolParameters)
 import           Convex.Query                   (balancePaymentCredentials)
@@ -297,7 +298,7 @@ balanceMultiAddress = do
           $ classify (null requiredSignatures) "0 required signatures"
           $ classify (not (null requiredSignatures) && length requiredSignatures <= 9) "1-9 required signatures"
           $ classify (length requiredSignatures > 9) "10+ required signatures"
-          $ runMockchainPropErr @(BalanceTxError C.ConwayEra) $ do
+          $ runMockchainProp $ runTestableErr @(BalanceTxError C.ConwayEra) $ do
               -- send Ada to each operator
               traverse_ (payToOperator' mempty (C.lovelaceToValue $ 7_500_000 + C.quantityToLovelace nAmount) Wallet.w2) (op:operators)
 

--- a/src/devnet/lib/Convex/Devnet/NodeQueries.hs
+++ b/src/devnet/lib/Convex/Devnet/NodeQueries.hs
@@ -194,7 +194,7 @@ waitForTxIn networkId socket txIn = do
               )
           )
       go = do
-        utxo <- Utxos.fromApiUtxo () <$> (queryLocalState query networkId socket >>= throwOnEraMismatch)
+        utxo <- Utxos.fromApiUtxo <$> (queryLocalState query networkId socket >>= throwOnEraMismatch)
         when (utxo == mempty) $ do
           threadDelay 2_000_000
           go
@@ -216,7 +216,7 @@ waitForTxInSpend networkId socket txIn = do
               )
           )
       go = do
-        utxo <- Utxos.fromApiUtxo () <$> (queryLocalState query networkId socket >>= throwOnEraMismatch)
+        utxo <- Utxos.fromApiUtxo <$> (queryLocalState query networkId socket >>= throwOnEraMismatch)
         unless (utxo == mempty) $ do
           threadDelay 2_000_000
           go

--- a/src/devnet/lib/Convex/Devnet/Wallet.hs
+++ b/src/devnet/lib/Convex/Devnet/Wallet.hs
@@ -59,9 +59,9 @@ faucet = Wallet . snd <$> keysFor "faucet"
 
 {-| Query the node for UTXOs that belong to the wallet
 -}
-walletUtxos :: forall era. C.IsShelleyBasedEra era => RunningNode -> Wallet -> IO (UtxoSet C.CtxUTxO era ())
+walletUtxos :: RunningNode -> Wallet -> IO (UtxoSet C.CtxUTxO ())
 walletUtxos RunningNode{rnNodeSocket, rnNetworkId} wllt =
-  Utxos.fromApiUtxo () <$> NodeQueries.queryUTxO rnNetworkId rnNodeSocket [address rnNetworkId wllt]
+  Utxos.fromApiUtxo <$> NodeQueries.queryUTxO @C.ConwayEra rnNetworkId rnNodeSocket [address rnNetworkId wllt]
 
 {-| Send @n@ times the given amount of lovelace to the address
 -}

--- a/src/devnet/lib/Convex/Devnet/Wallet.hs
+++ b/src/devnet/lib/Convex/Devnet/Wallet.hs
@@ -59,9 +59,9 @@ faucet = Wallet . snd <$> keysFor "faucet"
 
 {-| Query the node for UTXOs that belong to the wallet
 -}
-walletUtxos :: RunningNode -> Wallet -> IO (UtxoSet C.CtxUTxO ())
+walletUtxos :: forall era. C.IsShelleyBasedEra era => RunningNode -> Wallet -> IO (UtxoSet C.CtxUTxO era ())
 walletUtxos RunningNode{rnNodeSocket, rnNetworkId} wllt =
-  Utxos.fromApiUtxo () . C.inAnyCardanoEra C.cardanoEra <$> NodeQueries.queryUTxO rnNetworkId rnNodeSocket [address rnNetworkId wllt]
+  Utxos.fromApiUtxo () <$> NodeQueries.queryUTxO rnNetworkId rnNodeSocket [address rnNetworkId wllt]
 
 {-| Send @n@ times the given amount of lovelace to the address
 -}
@@ -84,21 +84,21 @@ createSeededWallet tracer node@RunningNode{rnNetworkId, rnNodeSocket} n amount =
 @RunningNode@ for blockchain stuff
 -}
 runningNodeBlockchain ::
- forall e a. (Show e)
+  forall era a. (C.IsShelleyBasedEra era)
   => Tracer IO WalletLog
   -> RunningNode
-  -> (forall m. (MonadFail m, MonadLog m, MonadBlockchain m) => m a)
+  -> (forall m. (MonadFail m, MonadLog m, MonadBlockchain era m) => m a)
   -> IO a
 runningNodeBlockchain tracer RunningNode{rnNodeSocket, rnNetworkId} h =
   let info = NodeQueries.localNodeConnectInfo rnNetworkId rnNodeSocket
   in runTracerMonadLogT tracer $ do
-      runMonadBlockchainCardanoNodeT @e info h >>= either (fail . show) pure
+      runMonadBlockchainCardanoNodeT @era info h
 
 {-| Balance and submit the transaction using the wallet's UTXOs
 -}
-balanceAndSubmit :: Tracer IO WalletLog -> RunningNode -> Wallet -> TxBuilder -> ChangeOutputPosition -> [C.ShelleyWitnessSigningKey] -> IO (Tx ConwayEra)
+balanceAndSubmit :: forall era. (C.IsShelleyBasedEra era, C.IsBabbageBasedEra era) => Tracer IO WalletLog -> RunningNode -> Wallet -> TxBuilder era -> ChangeOutputPosition -> [C.ShelleyWitnessSigningKey] -> IO (Tx era)
 balanceAndSubmit tracer node wallet tx changePosition keys = do
-  n <- runningNodeBlockchain @String tracer node queryNetworkId
+  n <- runningNodeBlockchain @era tracer node queryNetworkId
   let walletAddress = Wallet.addressInEra n wallet
       txOut = emptyTxOut walletAddress
   balanceAndSubmitReturn tracer node wallet txOut tx changePosition keys
@@ -106,20 +106,20 @@ balanceAndSubmit tracer node wallet tx changePosition keys = do
 {-| Balance and submit the transaction using the wallet's UTXOs
 -}
 balanceAndSubmitReturn
-  :: Tracer IO WalletLog
+  :: forall era. (C.IsShelleyBasedEra era, C.IsBabbageBasedEra era)
+  => Tracer IO WalletLog
   -> RunningNode
   -> Wallet
-  -> C.TxOut C.CtxTx C.ConwayEra
-  -> TxBuilder
+  -> C.TxOut C.CtxTx era
+  -> TxBuilder era
   -> ChangeOutputPosition
   -> [C.ShelleyWitnessSigningKey]
-  -> IO (Tx ConwayEra)
+  -> IO (Tx era)
 balanceAndSubmitReturn tracer node wallet returnOutput tx changePosition keys = do
   utxos <- walletUtxos node wallet
-  runningNodeBlockchain @String tracer node $ do
-    (C.Tx body wit, _) <- failOnError (CoinSelection.balanceForWalletReturn mempty wallet utxos (C.InAnyCardanoEra C.ConwayEra returnOutput) tx changePosition)
-
-    let wit' = (C.makeShelleyKeyWitness C.ShelleyBasedEraConway body <$> keys) ++ wit
+  runningNodeBlockchain tracer node $ do
+    (C.Tx body wit, _) <- failOnError (CoinSelection.balanceForWalletReturn @era mempty wallet utxos returnOutput tx changePosition)
+    let wit' = (C.makeShelleyKeyWitness C.shelleyBasedEra body <$> keys) ++ wit
         tx'  = C.makeSignedTransaction wit' body
 
     _ <- sendTx tx'

--- a/src/devnet/lib/Convex/Devnet/WalletServer.hs
+++ b/src/devnet/lib/Convex/Devnet/WalletServer.hs
@@ -161,7 +161,7 @@ opConfigArgs OperatorConfigVerification{ocvPaymentKeyFile, ocvStakeVerificationK
   ] ++
     maybe [] (\f -> ["--stake-verification-key-file", f]) ocvStakeVerificationKeyFile
 
-getUTxOs :: RunningWalletServer -> IO (UtxoSet CtxTx ())
+getUTxOs :: C.IsShelleyBasedEra era => RunningWalletServer -> IO (UtxoSet CtxTx era ())
 getUTxOs RunningWalletServer{rwsClient} = API.getUTxOs rwsClient >>= \case
   Left err -> error ("getUTxOs failed: " <> show err)
   Right x  -> pure x

--- a/src/devnet/lib/Convex/Devnet/WalletServer.hs
+++ b/src/devnet/lib/Convex/Devnet/WalletServer.hs
@@ -161,7 +161,7 @@ opConfigArgs OperatorConfigVerification{ocvPaymentKeyFile, ocvStakeVerificationK
   ] ++
     maybe [] (\f -> ["--stake-verification-key-file", f]) ocvStakeVerificationKeyFile
 
-getUTxOs :: C.IsShelleyBasedEra era => RunningWalletServer -> IO (UtxoSet CtxTx era ())
+getUTxOs :: RunningWalletServer -> IO (UtxoSet CtxTx ())
 getUTxOs RunningWalletServer{rwsClient} = API.getUTxOs rwsClient >>= \case
   Left err -> error ("getUTxOs failed: " <> show err)
   Right x  -> pure x

--- a/src/devnet/test/Spec.hs
+++ b/src/devnet/test/Spec.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE TypeApplications   #-}
 module Main where
 
 import qualified Cardano.Api                     as C
@@ -197,7 +197,7 @@ makePayment = do
           let lovelacePerUtxo = 100_000_000
               numUtxos        = 10
           wllt <- W.createSeededWallet (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
-          bal <- Utxos.totalBalance <$> W.walletUtxos @C.ConwayEra runningNode wllt
+          bal <- Utxos.totalBalance <$> W.walletUtxos runningNode wllt
           assertEqual "Wallet should have the expected balance" (fromIntegral numUtxos * lovelacePerUtxo) (C.lovelaceToQuantity $ C.selectLovelace bal)
 
 runWalletServer :: IO ()
@@ -206,7 +206,7 @@ runWalletServer =
     withTempDir "cardano-cluster" $ \tmp -> do
       withCardanoNodeDevnet (contramap TLNode tr) tmp $ \node ->
         withWallet (contramap TWallet tr) tmp node $ \wllt -> do
-          bal <- Utxos.totalBalance <$> getUTxOs @C.ConwayEra wllt
+          bal <- Utxos.totalBalance <$> getUTxOs wllt
           let lovelacePerUtxo = 100_000_000
               numUtxos        = 10 :: Int
           assertEqual "Wallet should have the correct balance" (fromIntegral numUtxos * lovelacePerUtxo) (C.selectLovelace bal)

--- a/src/devnet/test/Spec.hs
+++ b/src/devnet/test/Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -196,7 +197,7 @@ makePayment = do
           let lovelacePerUtxo = 100_000_000
               numUtxos        = 10
           wllt <- W.createSeededWallet (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
-          bal <- Utxos.totalBalance <$> W.walletUtxos runningNode wllt
+          bal <- Utxos.totalBalance <$> W.walletUtxos @C.ConwayEra runningNode wllt
           assertEqual "Wallet should have the expected balance" (fromIntegral numUtxos * lovelacePerUtxo) (C.lovelaceToQuantity $ C.selectLovelace bal)
 
 runWalletServer :: IO ()
@@ -205,7 +206,7 @@ runWalletServer =
     withTempDir "cardano-cluster" $ \tmp -> do
       withCardanoNodeDevnet (contramap TLNode tr) tmp $ \node ->
         withWallet (contramap TWallet tr) tmp node $ \wllt -> do
-          bal <- Utxos.totalBalance <$> getUTxOs wllt
+          bal <- Utxos.totalBalance <$> getUTxOs @C.ConwayEra wllt
           let lovelacePerUtxo = 100_000_000
               numUtxos        = 10 :: Int
           assertEqual "Wallet should have the correct balance" (fromIntegral numUtxos * lovelacePerUtxo) (C.selectLovelace bal)

--- a/src/mockchain/convex-mockchain.cabal
+++ b/src/mockchain/convex-mockchain.cabal
@@ -50,8 +50,6 @@ library
       sop-extras,
       strict-sop-core,
       sop-core,
-      template-haskell,
-      aeson,
       primitive
 
     -- cardano dependencies

--- a/src/mockchain/lib/Convex/MockChain.hs
+++ b/src/mockchain/lib/Convex/MockChain.hs
@@ -1,19 +1,20 @@
-{-# LANGUAGE DataKinds          #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE NamedFieldPuns     #-}
-{-# LANGUAGE RankNTypes         #-}
-{-# LANGUAGE TemplateHaskell    #-}
-{-# LANGUAGE TypeApplications   #-}
-{-# LANGUAGE TypeFamilies       #-}
-{-# LANGUAGE TypeOperators      #-}
-{-# LANGUAGE ViewPatterns       #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns         #-}
 {-| Minimal mockchain
 -}
 module Convex.MockChain(
   -- * State of the mockchain
-  ERA,
   MockChainState(..),
   InitialUTXOs,
   initialState,
@@ -42,7 +43,6 @@ module Convex.MockChain(
   PlutusWithContext(..),
   fullyAppliedScript,
   -- * Mockchain implementation
-  MockchainError(..),
   MockchainT(..),
   Mockchain,
   runMockchainT,
@@ -63,15 +63,18 @@ module Convex.MockChain(
   evalMockchainIO,
   evalMockchain0IO,
   execMockchainIO,
-  execMockchain0IO
+  execMockchain0IO,
+  runMockchain0T,
+  evalMockchain0T
   ) where
 
-import           Cardano.Api.Shelley                   (AddressInEra, ConwayEra,
+import           Cardano.Api.Shelley                   (AddressInEra,
                                                         Hash (StakePoolKeyHash),
                                                         ShelleyLedgerEra,
                                                         SlotNo, Tx,
                                                         TxBody (ShelleyTxBody))
 import qualified Cardano.Api.Shelley                   as C
+import qualified Cardano.Ledger.Alonzo.Core            as L
 import           Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError,
                                                         collectPlutusScriptsWithContext,
                                                         evalPlutusScripts)
@@ -81,7 +84,6 @@ import           Cardano.Ledger.BaseTypes              (Globals (systemStart),
                                                         epochInfo, getVersion,
                                                         pvMajor)
 import           Cardano.Ledger.Conway                 (Conway)
-import           Cardano.Ledger.Conway.Tx              (AlonzoTx (..))
 import qualified Cardano.Ledger.Core                   as Core
 import           Cardano.Ledger.Crypto                 (StandardCrypto)
 import           Cardano.Ledger.Plutus.Evaluate        (PlutusWithContext (..),
@@ -108,19 +110,19 @@ import           Cardano.Ledger.UMap                   (RDPair (..),
                                                         domRestrictedMap,
                                                         fromCompact)
 import qualified Cardano.Ledger.Val                    as Val
-import           Control.Lens                          (_1, _3, over, to, view,
-                                                        (%=), (&), (.~), (^.))
+import           Control.Lens                          (_1, _3, over, set, to,
+                                                        view, (%=), (&), (.~),
+                                                        (^.))
 import           Control.Monad                         (forM)
-import           Control.Monad.Except                  (ExceptT,
-                                                        MonadError (throwError),
-                                                        runExceptT)
+import           Control.Monad.Except                  (MonadError (throwError))
 import           Control.Monad.IO.Class                (MonadIO)
-import           Control.Monad.Primitive               (PrimMonad (..))
+import           Control.Monad.Primitive               (PrimMonad)
 import           Control.Monad.Reader                  (MonadReader, ReaderT,
                                                         ask, asks, local,
                                                         runReaderT)
-import           Control.Monad.State                   (MonadState, StateT, get,
-                                                        gets, put, runStateT)
+import           Control.Monad.State.Strict            (MonadState, StateT, get,
+                                                        gets, put, runStateT,
+                                                        state)
 import           Control.Monad.Trans.Class             (MonadTrans (..))
 import qualified Convex.CardanoApi.Lenses              as L
 import           Convex.Class                          (ExUnitsError (..),
@@ -129,7 +131,6 @@ import           Convex.Class                          (ExUnitsError (..),
                                                         MonadDatumQuery (..),
                                                         MonadMockchain (..),
                                                         MonadUtxoQuery (..),
-                                                        SendTxFailed (..),
                                                         ValidationError (..),
                                                         _ApplyTxFailure,
                                                         _Phase1Error,
@@ -139,12 +140,12 @@ import           Convex.Class                          (ExUnitsError (..),
                                                         failedTransactions,
                                                         modifyUtxo, poolState,
                                                         transactions)
-import           Convex.Constants                      (ERA)
 import           Convex.MockChain.Defaults             ()
 import qualified Convex.MockChain.Defaults             as Defaults
 import           Convex.MonadLog                       (MonadLog (..))
 import           Convex.NodeParams                     (NodeParams (..))
-import           Convex.Utils                          (slotToUtcTime)
+import           Convex.Utils                          (alonzoEraUtxo, inAlonzo,
+                                                        slotToUtcTime)
 import           Convex.Utxos                          (UtxoSet (..),
                                                         fromApiUtxo,
                                                         onlyCredential,
@@ -168,7 +169,7 @@ import qualified UntypedPlutusCore                     as UPLC
 {-| Apply the plutus script to all its arguments and return a plutus
 program
 -}
-fullyAppliedScript :: NodeParams -> PlutusWithContext StandardCrypto -> Either String (UPLC.Program UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ())
+fullyAppliedScript :: NodeParams C.ConwayEra -> PlutusWithContext StandardCrypto -> Either String (UPLC.Program UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ())
 fullyAppliedScript params pwc@PlutusWithContext{pwcScript} = do
   let plutus = either id Plutus.Language.plutusFromRunnable pwcScript
       binScript = Plutus.Language.plutusBinary plutus
@@ -228,7 +229,7 @@ legacyPlutusArgsToData = \case
   LegacyPlutusArgs2 redeemer scriptContext -> [redeemer, PV3.toData scriptContext]
   LegacyPlutusArgs3 datum redeemer scriptContext -> [datum, redeemer, PV3.toData scriptContext]
 
-initialState :: NodeParams -> MockChainState
+initialState :: C.IsShelleyBasedEra era => NodeParams era -> MockChainState era
 initialState params = initialStateFor params []
 
 genesisUTxO ::
@@ -250,11 +251,12 @@ type InitialUTXOs = [(Wallet, Coin)]
 {-| Initialise the 'MockChainState' with a list of UTxOs
 -}
 initialStateFor ::
-  NodeParams ->
+  forall era. C.IsShelleyBasedEra era =>
+  NodeParams era ->
   InitialUTXOs -> -- List of UTXOs at each wallet's address. Can have multiple entries per wallet.
-  MockChainState
-initialStateFor params@NodeParams{npNetworkId} utxos =
-  let utxo = genesisUTxO @ERA @C.ConwayEra (fmap (first (addressInEra npNetworkId)) utxos)
+  MockChainState era
+initialStateFor params@NodeParams{npNetworkId} utxos = C.shelleyBasedEraConstraints @era C.shelleyBasedEra $
+  let utxo = genesisUTxO @_ @era (fmap (first (addressInEra npNetworkId)) utxos)
   in MockChainState
       { mcsEnv =
           LedgerEnv
@@ -272,28 +274,31 @@ initialStateFor params@NodeParams{npNetworkId} utxos =
       , mcsDatums = Map.empty
       }
 
-utxoEnv :: NodeParams -> SlotNo -> UtxoEnv ERA
+utxoEnv :: NodeParams era -> SlotNo -> UtxoEnv (C.ShelleyLedgerEra era)
 utxoEnv params slotNo = UtxoEnv slotNo (Defaults.pParams params) def
 
 {-| Compute the exunits of a transaction
 -}
 getTxExUnits ::
-  NodeParams ->
-  UTxO ERA ->
-  C.Tx C.ConwayEra ->
-  Either ExUnitsError (Map.Map C.ScriptWitnessIndex C.ExecutionUnits)
+  forall era.
+  C.IsShelleyBasedEra era =>
+  NodeParams era ->
+  UTxO (C.ShelleyLedgerEra era) ->
+  C.Tx era ->
+  Either (ExUnitsError era) (Map.Map C.ScriptWitnessIndex C.ExecutionUnits)
 getTxExUnits NodeParams{npSystemStart, npEraHistory, npProtocolParameters} utxo (C.getTxBody -> tx) =
-  case C.evaluateTransactionExecutionUnits C.ConwayEra npSystemStart (C.toLedgerEpochInfo npEraHistory) npProtocolParameters (fromLedgerUTxO C.ShelleyBasedEraConway utxo) tx of
+  C.shelleyBasedEraConstraints @era C.shelleyBasedEra $
+  case C.evaluateTransactionExecutionUnits C.cardanoEra npSystemStart (C.toLedgerEpochInfo npEraHistory) npProtocolParameters (fromLedgerUTxO C.shelleyBasedEra utxo) tx of
     Left e      -> Left (Phase1Error e)
     Right rdmrs -> traverse (either (Left . Phase2Error) (Right . snd)) rdmrs
 
-applyTransaction :: NodeParams -> MockChainState -> C.Tx C.ConwayEra -> Either ValidationError (MockChainState, Validated (Core.Tx ERA))
-applyTransaction params state tx'@(C.ShelleyTx _era tx) = do
-  let currentSlot = state ^. env . L.slot
-      utxoState_ = state ^. poolState . L.utxoState
+applyTransaction :: forall era. (C.IsAlonzoBasedEra era) => NodeParams era -> MockChainState era -> C.Tx era -> Either (ValidationError era) (MockChainState era, Validated (Core.Tx (C.ShelleyLedgerEra era)))
+applyTransaction params state' tx'@(C.ShelleyTx _era tx) = C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $ do
+  let currentSlot = state' ^. env . L.slot
+      utxoState_ = state' ^. poolState . L.utxoState
       utxo = utxoState_ ^. L._UTxOState (C.unLedgerProtocolParameters $ npProtocolParameters params) . _1
   (vtx, scripts) <- first PredicateFailures (constructValidated (Defaults.globals params) (utxoEnv params currentSlot) utxoState_ tx)
-  result <- applyTx params state vtx scripts
+  result <- applyTx params state' vtx scripts
 
   -- Not sure if this step is needed.
   _ <- first VExUnits (getTxExUnits params utxo tx')
@@ -302,13 +307,13 @@ applyTransaction params state tx'@(C.ShelleyTx _era tx) = do
 
 {-| Evaluate a transaction, returning all of its script contexts.
 -}
-evaluateTx :: NodeParams -> SlotNo -> UTxO ERA -> C.Tx C.ConwayEra -> Either ValidationError [PlutusWithContext StandardCrypto]
+evaluateTx :: NodeParams C.ConwayEra -> SlotNo -> UTxO Conway -> C.Tx C.ConwayEra -> Either (ValidationError C.ConwayEra) [PlutusWithContext StandardCrypto]
 evaluateTx params slotNo utxo (C.ShelleyTx _ tx) = do
-    (vtx, scripts) <- first PredicateFailures (constructValidated (Defaults.globals params) (utxoEnv params slotNo) (lsUTxOState (mcsPoolState state)) tx)
-    _ <- applyTx params state vtx scripts
+    (vtx, scripts) <- first PredicateFailures (constructValidated (Defaults.globals params) (utxoEnv params slotNo) (lsUTxOState (mcsPoolState state')) tx)
+    _ <- applyTx params state' vtx scripts
     pure scripts
   where
-    state =
+    state' =
       initialState params
         & env . L.slot .~ slotNo
         & poolState . L.utxoState . L._UTxOState (C.unLedgerProtocolParameters $ npProtocolParameters params) . _1 .~ utxo
@@ -323,25 +328,23 @@ evaluateTx params slotNo utxo (C.ShelleyTx _ tx) = do
 -- Copied from cardano-ledger as it was removed there
 -- in https://github.com/input-output-hk/cardano-ledger/commit/721adb55b39885847562437a6fe7e998f8e48c03
 constructValidated ::
-  forall m.
-  ( MonadError [CollectError Conway] m
+  forall era m.
+  ( MonadError [CollectError (C.ShelleyLedgerEra era)] m
+  , C.IsAlonzoBasedEra era
   ) =>
   Globals ->
-  UtxoEnv Conway ->
-  UTxOState Conway ->
-  Core.Tx Conway ->
-  m (AlonzoTx Conway, [PlutusWithContext StandardCrypto])
+  UtxoEnv (C.ShelleyLedgerEra era) ->
+  UTxOState (C.ShelleyLedgerEra era) ->
+  Core.Tx (C.ShelleyLedgerEra era) ->
+  m (Core.Tx (C.ShelleyLedgerEra era), [PlutusWithContext StandardCrypto])
 constructValidated globals (UtxoEnv _ pp _) st tx =
+  C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $
+  alonzoEraUtxo @era $
   case collectPlutusScriptsWithContext ei sysS pp tx utxo of
     Left errs -> throwError errs
     Right sLst ->
-      let scriptEvalResult = evalPlutusScripts @(EraCrypto Conway) sLst
-          vTx =
-            AlonzoTx
-              (body tx)
-              (wits tx) -- (getField @"wits" tx)
-              (IsValid (lift_ scriptEvalResult))
-              (auxiliaryData tx) -- (getField @"auxiliaryData" tx)
+      let scriptEvalResult = evalPlutusScripts @(EraCrypto (C.ShelleyLedgerEra era)) sLst
+          vTx = set L.isValidTxL (IsValid (lift_ scriptEvalResult)) tx
        in pure (vTx, sLst)
   where
     utxo = utxosUtxo st
@@ -351,60 +354,51 @@ constructValidated globals (UtxoEnv _ pp _) st tx =
     lift_ (Fails _ _) = False
 
 applyTx ::
-  NodeParams ->
-  MockChainState ->
-  Core.Tx ERA ->
+  forall era.
+  C.IsShelleyBasedEra era =>
+  NodeParams era ->
+  MockChainState era ->
+  Core.Tx (C.ShelleyLedgerEra era) ->
   [PlutusWithContext StandardCrypto] ->
-  Either ValidationError (MockChainState, Validated (Core.Tx ERA))
-applyTx params oldState@MockChainState{mcsEnv, mcsPoolState} tx context = do
+  Either (ValidationError era) (MockChainState era, Validated (Core.Tx (C.ShelleyLedgerEra era)))
+applyTx params oldState@MockChainState{mcsEnv, mcsPoolState} tx context = C.shelleyBasedEraConstraints @era C.shelleyBasedEra $ do
   (newMempool, vtx) <- first ApplyTxFailure (Cardano.Ledger.Shelley.API.applyTx (Defaults.globals params) mcsEnv mcsPoolState tx)
   return (oldState & poolState .~ newMempool & over transactions ((vtx,context) :) , vtx)
 
-newtype MockchainT m a = MockchainT (ReaderT NodeParams (StateT MockChainState (ExceptT MockchainError m)) a)
-  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadLog)
+newtype MockchainT era m a = MockchainT (ReaderT (NodeParams era) (StateT (MockChainState era) m) a)
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadLog, MonadFail, PrimMonad)
 
-instance PrimMonad m => PrimMonad (MockchainT m) where
-  type PrimState (MockchainT m) = PrimState m
-  {-# INLINEABLE primitive #-}
-  primitive f = lift (primitive f)
+instance MonadTrans (MockchainT era) where
+  lift = MockchainT . lift . lift
 
-instance MonadTrans MockchainT where
-  lift = MockchainT . lift . lift . lift
-
-instance Monad m => MonadReader NodeParams (MockchainT m) where
+instance Monad m => MonadReader (NodeParams era) (MockchainT era m) where
   ask = MockchainT ask
   local f (MockchainT m) = MockchainT $ local f m
 
-instance Monad m => MonadState MockChainState (MockchainT m) where
+instance Monad m => MonadState (MockChainState era) (MockchainT era m) where
   get = MockchainT $ lift get
   put = MockchainT . lift . put
 
-data MockchainError =
-  FailWith String
-  deriving (Show)
-
-instance Monad m => MonadFail (MockchainT m) where
-  fail = MockchainT . throwError . FailWith
-
-instance Monad m => MonadBlockchain (MockchainT m) where
-  sendTx tx = MockchainT $ do
+instance (MonadFail m, C.IsAlonzoBasedEra era) => MonadBlockchain era (MockchainT era m) where
+  sendTx tx = MockchainT $ C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $ do
     nps <- ask
     addDatumHashes tx
     st <- get
     case applyTransaction nps st tx of
       Left err       -> do
-        failedTransactions %= ((:) (tx, err))
-        return $ Left $ SendTxFailed $ show err
+        failedTransactions %= ((tx, err) :)
+        return $ Left err
       Right (st', _) ->
         let C.Tx body _ = tx
         in put st' >> return (Right $ C.getTxId body)
-  utxoByTxIn txIns = MockchainT $ do
+  utxoByTxIn txIns = MockchainT $ C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $ do
     nps <- ask
-    C.UTxO mp <- gets (view $ poolState . L.utxoState . L._UTxOState (Defaults.pParams nps) . _1 . to (fromLedgerUTxO C.ShelleyBasedEraConway))
+    C.UTxO mp <- gets (view $ poolState . L.utxoState . L._UTxOState (Defaults.pParams nps) . _1 . to (fromLedgerUTxO C.shelleyBasedEra))
     let mp' = Map.restrictKeys mp txIns
     pure (C.UTxO mp')
+
   queryProtocolParameters = MockchainT (asks npProtocolParameters)
-  queryStakeAddresses creds nid = MockchainT $ do
+  queryStakeAddresses creds nid = MockchainT $ C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $ do
     dState <- gets (view $ poolState . lsCertStateL . certDStateL)
     let
       creds' = toLedgerStakeCredentials creds
@@ -432,35 +426,35 @@ instance Monad m => MonadBlockchain (MockchainT m) where
     st <- get
     NodeParams{npSystemStart, npEraHistory, npSlotLength} <- ask
     let slotNo = st ^. env . L.slot
-    utime <- either (throwError . FailWith) pure (slotToUtcTime npEraHistory npSystemStart slotNo)
+    utime <- either fail pure (slotToUtcTime npEraHistory npSystemStart slotNo)
     return (slotNo, npSlotLength, utime)
 
-instance Monad m => MonadMockchain (MockchainT m) where
-  modifyMockChainState f = MockchainT $ get >>= \st -> let (s, a) = f st in put s >> pure a
+instance (MonadFail m, C.IsAlonzoBasedEra era) => MonadMockchain era (MockchainT era m) where
+  modifyMockChainState f = MockchainT $ state f
   askNodeParams = ask
 
-instance Monad m => MonadUtxoQuery (MockchainT m) where
-  utxosByPaymentCredentials cred = do
+instance (MonadFail m, C.IsAlonzoBasedEra era) => MonadUtxoQuery era (MockchainT era m) where
+  utxosByPaymentCredentials cred = inAlonzo @era $ do
     UtxoSet utxos <- fmap (onlyCredentials cred) utxoSet
     let
-      resolveDatum :: C.TxOutDatum C.CtxUTxO era -> MockchainT m (Maybe C.HashableScriptData)
+      resolveDatum :: C.TxOutDatum C.CtxUTxO era -> MockchainT era m (Maybe C.HashableScriptData)
       resolveDatum C.TxOutDatumNone         = pure Nothing
       resolveDatum (C.TxOutDatumHash _ dh)  = queryDatumFromHash dh
       resolveDatum (C.TxOutDatumInline _ d) = pure $ Just d
 
-    resolvedUtxos <- forM utxos $ \(txOut@(C.InAnyCardanoEra _ (C.TxOut _ _ d _)), _) -> do
+    resolvedUtxos <- forM utxos $ \(txOut@(C.TxOut _ _ d _), _) -> do
       resolvedDatum <- resolveDatum d
       pure (txOut, resolvedDatum)
     pure $ UtxoSet resolvedUtxos
 
-instance Monad m => MonadDatumQuery (MockchainT m) where
+instance Monad m => MonadDatumQuery (MockchainT era m) where
   queryDatumFromHash dh = MockchainT (gets (Map.lookup dh . view datums))
 
 {-| Add all datums from the transaction to the map of known datums
 -}
-addDatumHashes :: MonadState MockChainState m => Tx ConwayEra -> m ()
-addDatumHashes (C.Tx (ShelleyTxBody C.ShelleyBasedEraConway txBody _scripts scriptData _auxData _) _witnesses) = do
-  let txOuts = C.fromLedgerTxOuts C.ShelleyBasedEraConway txBody scriptData
+addDatumHashes :: MonadState (MockChainState era) m => Tx era -> m ()
+addDatumHashes (C.Tx (ShelleyTxBody era txBody _scripts scriptData _auxData _) _witnesses) = do
+  let txOuts = C.fromLedgerTxOuts era txBody scriptData
 
   let insertHashableScriptData hashableScriptData =
         datums %= Map.insert (C.hashScriptDataBytes hashableScriptData) hashableScriptData
@@ -476,81 +470,90 @@ addDatumHashes (C.Tx (ShelleyTxBody C.ShelleyBasedEraConway txBody _scripts scri
 
 {-| All transaction outputs
 -}
-utxoSet :: MonadMockchain m => m (UtxoSet C.CtxUTxO ())
+utxoSet :: forall era m. (MonadMockchain era m, C.IsShelleyBasedEra era) => m (UtxoSet C.CtxUTxO era ())
 utxoSet =
-  let f utxos = (utxos, fromApiUtxo () $ C.inAnyCardanoEra C.cardanoEra $ fromLedgerUTxO C.ShelleyBasedEraConway utxos)
-  in modifyUtxo f
+  let f utxos = (utxos, fromApiUtxo () $ fromLedgerUTxO C.shelleyBasedEra utxos)
+  in modifyUtxo $ C.shelleyBasedEraConstraints @era C.shelleyBasedEra f
 
 {-| The wallet's transaction outputs on the mockchain
 -}
-walletUtxo :: MonadMockchain m => Wallet -> m (UtxoSet C.CtxUTxO ())
+walletUtxo :: (MonadMockchain era m, C.IsShelleyBasedEra era) => Wallet -> m (UtxoSet C.CtxUTxO era ())
 walletUtxo wallet = do
   fmap (onlyCredential (paymentCredential wallet)) utxoSet
 
 {-| Run the 'MockchainT' action with the @NodeParams@ from an initial state
 -}
-runMockchainT :: MockchainT m a -> NodeParams -> MockChainState -> m (Either MockchainError (a, MockChainState))
-runMockchainT (MockchainT action) nps state =
-  runExceptT (runStateT (runReaderT action nps) state)
+runMockchainT :: MockchainT era m a -> NodeParams era -> MockChainState era -> m (a, MockChainState era)
+runMockchainT (MockchainT action) nps state' =
+  runStateT (runReaderT action nps) state'
 
-type Mockchain a = MockchainT Identity a
+type Mockchain era a = MockchainT era Identity a
 
-runMockchain :: Mockchain a -> NodeParams -> MockChainState -> Either MockchainError (a, MockChainState)
+runMockchain :: Mockchain era a -> NodeParams era -> MockChainState era -> (a, MockChainState era)
 runMockchain action nps = runIdentity . runMockchainT action nps
 
 {-| Run the mockchain action with an initial distribution, using the default node parameters
 -}
-runMockchain0 :: InitialUTXOs -> Mockchain a -> Either MockchainError (a, MockChainState)
+runMockchain0 :: InitialUTXOs -> Mockchain C.ConwayEra a -> (a, MockChainState C.ConwayEra)
 runMockchain0 dist = runMockchain0With dist Defaults.nodeParams
 
 {-| Run the mockchain action with an initial distribution and a given set of node params
 -}
-runMockchain0With :: InitialUTXOs -> NodeParams -> Mockchain a -> Either MockchainError (a, MockChainState)
+runMockchain0With :: C.IsShelleyBasedEra era => InitialUTXOs -> NodeParams era -> Mockchain era a -> (a, MockChainState era)
 runMockchain0With dist params action = runMockchain action params (initialStateFor params dist)
 
-evalMockchainT :: Functor m => MockchainT m a -> NodeParams -> MockChainState -> m (Either MockchainError a)
-evalMockchainT action nps = fmap (fmap fst) . runMockchainT action nps
+evalMockchainT :: Functor m => MockchainT era m a -> NodeParams era -> MockChainState era -> m a
+evalMockchainT action nps = fmap fst . runMockchainT action nps
 
-evalMockchain :: Mockchain a -> NodeParams -> MockChainState -> Either MockchainError a
+evalMockchain :: Mockchain era a -> NodeParams era -> MockChainState era -> a
 evalMockchain action nps = runIdentity . evalMockchainT action nps
 
-evalMockchain0 :: InitialUTXOs -> Mockchain a -> Either MockchainError a
+evalMockchain0 :: InitialUTXOs -> Mockchain C.ConwayEra a -> a
 evalMockchain0 dist action = evalMockchain action Defaults.nodeParams (initialStateFor Defaults.nodeParams dist)
 
-execMockchainT :: Functor m => MockchainT m a -> NodeParams -> MockChainState -> m (Either MockchainError MockChainState)
-execMockchainT action nps = fmap (fmap snd) . runMockchainT action nps
+execMockchainT :: Functor m => MockchainT era m a -> NodeParams era -> MockChainState era -> m (MockChainState era)
+execMockchainT action nps = fmap snd . runMockchainT action nps
 
-execMockchain :: Mockchain a -> NodeParams -> MockChainState -> Either MockchainError MockChainState
+execMockchain :: Mockchain era a -> NodeParams era -> MockChainState era -> MockChainState era
 execMockchain action nps = runIdentity . execMockchainT action nps
 
-execMockchain0 :: InitialUTXOs -> Mockchain a -> Either MockchainError MockChainState
+execMockchain0 :: InitialUTXOs -> Mockchain C.ConwayEra a -> MockChainState C.ConwayEra
 execMockchain0 dist action = execMockchain action Defaults.nodeParams (initialStateFor Defaults.nodeParams dist)
 
-type MockchainIO a = MockchainT IO a
+type MockchainIO era a = MockchainT era IO a
 
-runMockchainIO :: MockchainIO a -> NodeParams -> MockChainState -> IO (Either MockchainError (a, MockChainState))
-runMockchainIO action nps = runMockchainT action nps
+runMockchainIO :: MockchainIO era a -> NodeParams era -> MockChainState era -> IO (a, MockChainState era)
+runMockchainIO = runMockchainT
 
 {-| Run the mockchain IO action with an initial distribution, using the default node parameters
 -}
-runMockchain0IO :: InitialUTXOs -> MockchainIO a -> IO (Either MockchainError (a, MockChainState))
+runMockchain0IO :: InitialUTXOs -> MockchainIO C.ConwayEra a -> IO (a, MockChainState C.ConwayEra)
 runMockchain0IO dist = runMockchain0IOWith dist Defaults.nodeParams
+
+runMockchain0T :: InitialUTXOs -> MockchainT C.ConwayEra m a -> m (a, MockChainState C.ConwayEra)
+runMockchain0T dist = runMockchain0TWith dist Defaults.nodeParams
 
 {-| Run the mockchain IO action with an initial distribution and a given set of node params
 -}
-runMockchain0IOWith :: InitialUTXOs -> NodeParams -> MockchainIO a -> IO (Either MockchainError (a, MockChainState))
+runMockchain0IOWith :: C.IsShelleyBasedEra era => InitialUTXOs -> NodeParams era -> MockchainIO era a -> IO (a, MockChainState era)
 runMockchain0IOWith dist params action = runMockchainIO action params (initialStateFor params dist)
 
-evalMockchainIO :: MockchainIO a -> NodeParams -> MockChainState -> IO (Either MockchainError a)
-evalMockchainIO action nps = evalMockchainT action nps
+runMockchain0TWith :: C.IsShelleyBasedEra era => InitialUTXOs -> NodeParams era -> MockchainT era m a -> m (a, MockChainState era)
+runMockchain0TWith dist params action = runMockchainT action params (initialStateFor params dist)
 
-evalMockchain0IO :: InitialUTXOs -> MockchainIO a -> IO (Either MockchainError a)
+evalMockchainIO :: MockchainIO era a -> NodeParams era -> MockChainState era -> IO a
+evalMockchainIO = evalMockchainT
+
+evalMockchain0IO :: InitialUTXOs -> MockchainIO C.ConwayEra a -> IO a
 evalMockchain0IO dist action = evalMockchainIO action Defaults.nodeParams (initialStateFor Defaults.nodeParams dist)
 
-execMockchainIO :: MockchainIO a -> NodeParams -> MockChainState -> IO (Either MockchainError MockChainState)
+evalMockchain0T :: Functor m => InitialUTXOs -> MockchainT C.ConwayEra m a -> m a
+evalMockchain0T dist action = evalMockchainT action Defaults.nodeParams (initialStateFor Defaults.nodeParams dist)
+
+execMockchainIO :: MockchainIO era a -> NodeParams era -> MockChainState era -> IO (MockChainState era)
 execMockchainIO action nps = execMockchainT action nps
 
-execMockchain0IO :: InitialUTXOs -> MockchainIO a -> IO (Either MockchainError MockChainState)
+execMockchain0IO :: InitialUTXOs -> MockchainIO C.ConwayEra a -> IO (MockChainState C.ConwayEra)
 execMockchain0IO dist action = execMockchainIO action Defaults.nodeParams (initialStateFor Defaults.nodeParams dist)
 
 -- not exported by cardano-api 1.35.3 (though it seems like it's exported in 1.36)

--- a/src/mockchain/lib/Convex/MockChain/Defaults.hs
+++ b/src/mockchain/lib/Convex/MockChain/Defaults.hs
@@ -91,6 +91,8 @@ epochSize = EpochSize 432_000
 slotLength :: SlotLength
 slotLength = mkSlotLength 1 -- 1 second
 
+-- FIXME: Make this era independent
+
 protocolParameters :: PParams StandardConway
 protocolParameters = L.PParams $
     L.emptyPParamsIdentity @(ConwayEra StandardCrypto)

--- a/src/mockchain/lib/Convex/MockChain/Utils.hs
+++ b/src/mockchain/lib/Convex/MockChain/Utils.hs
@@ -13,13 +13,13 @@ module Convex.MockChain.Utils(
 
   -- * Running mockchain actions in QuickCheck tests
   runMockchainProp,
-  runMockchainPropErr,
-  runMockchainPropWith
+  runMockchainPropWith,
+  runTestableErr
   ) where
 
 import qualified Cardano.Api               as C
 import           Control.Exception         (SomeException, try)
-import           Control.Monad.Except      (ExceptT, MonadError, runExceptT)
+import           Control.Monad.Except      (ExceptT, runExceptT)
 import           Convex.MockChain          (InitialUTXOs, MockchainIO,
                                             MockchainT, initialStateFor,
                                             runMockchain, runMockchain0IOWith)
@@ -65,7 +65,7 @@ mockchainFailsWith params action handleError =
 as test failures.
 -}
 runMockchainPropWith ::
-  forall era e a. (Testable a, C.IsShelleyBasedEra era)
+  forall era a. (Testable a, C.IsShelleyBasedEra era)
   => NodeParams era
   -- ^ Node parameters to use for the mockchain
   -> InitialUTXOs
@@ -83,6 +83,8 @@ runMockchainPropWith nodeParams utxos =
 runMockchainProp :: forall a. (Testable a) => PropertyM (MockchainT C.ConwayEra Identity) a -> Property
 runMockchainProp = runMockchainPropWith Defaults.nodeParams Wallet.initialUTxOs
 
+{-| 'Either' with a 'Testable' instance for the 'Left' case
+-}
 newtype TestableErr e a = TestableErr (Either e a)
 
 instance (Show e, Testable a) => Testable (TestableErr e a) where
@@ -93,6 +95,5 @@ instance (Show e, Testable a) => Testable (TestableErr e a) where
 {-| Run the 'Mockchain' action as a QuickCheck property, using the default node params
     and initial distribution, and considering all 'MockchainError's as test failures.
 -}
-runMockchainPropErr :: forall e a. (Show e, Testable a) => ExceptT e (PropertyM (MockchainT C.ConwayEra Identity)) a -> Property
-runMockchainPropErr =
-  runMockchainPropWith Defaults.nodeParams Wallet.initialUTxOs . fmap TestableErr . runExceptT
+runTestableErr :: forall e m a. Functor m => ExceptT e m a -> m (TestableErr e a)
+runTestableErr = fmap TestableErr . runExceptT

--- a/src/mockchain/lib/Convex/MockChain/Utils.hs
+++ b/src/mockchain/lib/Convex/MockChain/Utils.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Utility functions for using the mockchain types in @hunit@ or @QuickCheck@ tests
 module Convex.MockChain.Utils(
   -- * Useful mockchain actions
@@ -15,69 +16,67 @@ module Convex.MockChain.Utils(
   runMockchainPropWith
   ) where
 
-import           Convex.MockChain          (InitialUTXOs, MockChainState (..),
-                                            MockchainError, MockchainIO,
-                                            MockchainT, initialStateFor,
-                                            runMockchain, runMockchain0IOWith)
+import qualified Cardano.Api               as C
+import           Control.Exception         (SomeException, try)
+import           Convex.MockChain          (InitialUTXOs, 
+                                            MockchainIO, MockchainT,
+                                            initialStateFor, runMockchain,
+                                            runMockchain0IOWith)
 import qualified Convex.MockChain.Defaults as Defaults
 import           Convex.NodeParams         (NodeParams)
 import qualified Convex.Wallet.MockWallet  as Wallet
-import           Data.Functor.Identity     (Identity (..))
+import           Data.Functor.Identity     (Identity)
 import           Test.HUnit                (Assertion)
-import           Test.QuickCheck           (Property, Testable, counterexample,
-                                            property)
+import           Test.QuickCheck           (Property, Testable)
 import           Test.QuickCheck.Monadic   (PropertyM (..), monadic)
 
 {-| Run the 'Mockchain' action and fail if there is an error
 -}
-mockchainSucceeds :: MockchainIO a -> Assertion
+mockchainSucceeds :: MockchainIO C.ConwayEra a -> Assertion
 mockchainSucceeds = mockchainSucceedsWith Defaults.nodeParams
 
 {-| Run the 'Mockchain' action with the given node parameters and fail if there is an error
 -}
-mockchainSucceedsWith :: NodeParams -> MockchainIO a -> Assertion
+mockchainSucceedsWith :: C.IsShelleyBasedEra era => NodeParams era -> MockchainIO era a -> Assertion
 mockchainSucceedsWith params action =
-   runMockchain0IOWith Wallet.initialUTxOs params action >>= \case
+   try @SomeException (runMockchain0IOWith Wallet.initialUTxOs params action) >>= \case
     Right{}  -> pure ()
     Left err -> fail (show err)
 
 {-| Run the 'Mockchain' action, fail if it succeeds, and handle the error
   appropriately.
 -}
-mockchainFails :: MockchainIO a -> (MockchainError -> Assertion) -> Assertion
-mockchainFails action =
-  mockchainFailsWith Defaults.nodeParams action
+mockchainFails :: MockchainIO C.ConwayEra a -> (SomeException -> Assertion) -> Assertion
+mockchainFails =
+  mockchainFailsWith Defaults.nodeParams
 
 {-| Run the 'Mockchain' action with the given node parameters, fail if it
     succeeds, and handle the error appropriately.
 -}
-mockchainFailsWith :: NodeParams -> MockchainIO a -> (MockchainError -> Assertion) -> Assertion
+mockchainFailsWith :: C.IsShelleyBasedEra era => NodeParams era -> MockchainIO era a -> (SomeException -> Assertion) -> Assertion
 mockchainFailsWith params action handleError =
-  runMockchain0IOWith Wallet.initialUTxOs params action >>= \case
-    Right _  -> fail ("mockchainFailsWith: Did not fail")
+  try @SomeException (runMockchain0IOWith Wallet.initialUTxOs params action) >>= \case
+    Right _  -> fail "mockchainFailsWith: Did not fail"
     Left err -> handleError err
 
 {-| Run the 'Mockchain' action as a QuickCheck property, considering all 'MockchainError'
 as test failures.
 -}
 runMockchainPropWith ::
-  forall a. (Testable a)
-  => NodeParams
+  forall era a. (Testable a, C.IsShelleyBasedEra era)
+  => NodeParams era
   -- ^ Node parameters to use for the mockchain
   -> InitialUTXOs
   -- ^ Initial distribution
-  -> PropertyM (MockchainT Identity) a
+  -> PropertyM (MockchainT era Identity) a
   -- ^ The mockchain action to run
   -> Property
 runMockchainPropWith nodeParams utxos =
   let iState = initialStateFor nodeParams utxos
-      resultToProp :: Either MockchainError (Property, MockChainState) -> Property
-      resultToProp (Right (prop, _)) = prop
-      resultToProp (Left err)        = counterexample (show err) $ property False
-  in monadic (\a -> resultToProp $ runMockchain a nodeParams iState)
+  in monadic (\a -> fst $ runMockchain a nodeParams iState)
 
 {-| Run the 'Mockchain' action as a QuickCheck property, using the default node params
     and initial distribution, and considering all 'MockchainError's as test failures.
 -}
-runMockchainProp :: forall a. (Testable a) => PropertyM (MockchainT Identity) a -> Property
+runMockchainProp :: forall a. (Testable a) => PropertyM (MockchainT C.ConwayEra Identity) a -> Property
 runMockchainProp = runMockchainPropWith Defaults.nodeParams Wallet.initialUTxOs

--- a/src/node-client/lib/Convex/NodeClient/WaitForTxnClient.hs
+++ b/src/node-client/lib/Convex/NodeClient/WaitForTxnClient.hs
@@ -68,7 +68,7 @@ checkTxId :: TxId -> C.Tx era -> Bool
 checkTxId txi tx = txi == C.getTxId (C.getTxBody tx)
 
 newtype MonadBlockchainWaitingT era m a = MonadBlockchainWaitingT{unMonadBlockchainWaitingT :: ReaderT (LocalNodeConnectInfo, Env) m a }
-  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadFail, MonadUtxoQuery era, MonadDatumQuery, MonadError e, MonadLog, PrimMonad)
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadFail, MonadUtxoQuery, MonadDatumQuery, MonadError e, MonadLog, PrimMonad)
 
 runMonadBlockchainWaitingT :: LocalNodeConnectInfo -> Env -> MonadBlockchainWaitingT era m a -> m a
 runMonadBlockchainWaitingT connectInfo env (MonadBlockchainWaitingT action) = runReaderT action (connectInfo, env)

--- a/src/optics/convex-optics.cabal
+++ b/src/optics/convex-optics.cabal
@@ -34,10 +34,9 @@ library
     hs-source-dirs: lib
     build-depends:
       base >= 4.14 && < 4.20,
-      cardano-api == 9.1.0.0,
+      cardano-api == 9.3.0.0,
       cardano-ledger-core,
       cardano-ledger-shelley,
-      cardano-ledger-mary,
       containers,
       lens,
       ouroboros-consensus-cardano,

--- a/src/optics/lib/Convex/CardanoApi/Lenses.hs
+++ b/src/optics/lib/Convex/CardanoApi/Lenses.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-deprecations #-} -- see https://github.com/j-mueller/sc-tools/issues/213
 {-| Lenses for @cardano-api@ types
 -}
 module Convex.CardanoApi.Lenses(

--- a/src/optics/lib/Convex/CardanoApi/Lenses.hs
+++ b/src/optics/lib/Convex/CardanoApi/Lenses.hs
@@ -6,14 +6,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-| Lenses for @cardano-api@ types
 -}
 module Convex.CardanoApi.Lenses(
-  IsAllegraEraOnwards (..),
-  IsMaryEraOnwards (..),
-  IsAlonzoEraOnwards (..),
-  IsBabbageEraOnwards (..),
-  IsConwayEraOnwards(..),
   -- * Tx body content lenses
   emptyTx,
   emptyTxOut,
@@ -124,7 +120,6 @@ import qualified Cardano.Ledger.Credential          as Credential
 import           Cardano.Ledger.Crypto              (StandardCrypto)
 import qualified Cardano.Ledger.Hashes              as Hashes
 import qualified Cardano.Ledger.Keys                as Keys
-import           Cardano.Ledger.Mary.Value          (MaryValue (..))
 import           Cardano.Ledger.Shelley.API         (Coin, LedgerEnv (..), UTxO,
                                                      UTxOState (..))
 import           Cardano.Ledger.Shelley.Governance  (GovState)
@@ -145,77 +140,6 @@ import           PlutusLedgerApi.V1.Interval        (Closure, Extended (..),
                                                      LowerBound (..),
                                                      UpperBound (..))
 import qualified PlutusTx.Prelude                   as PlutusTx
-
--- | The class of eras that are after Allegra.
--- TODO Move to cardano-api
-class C.IsCardanoEra era => IsAllegraEraOnwards era where
-   allegraEraOnwards :: C.AllegraEraOnwards era
-
-instance IsAllegraEraOnwards C.AllegraEra where
-   allegraEraOnwards = C.AllegraEraOnwardsAllegra
-
-instance IsAllegraEraOnwards C.MaryEra where
-   allegraEraOnwards = C.AllegraEraOnwardsMary
-
-instance IsAllegraEraOnwards C.AlonzoEra where
-   allegraEraOnwards = C.AllegraEraOnwardsAlonzo
-
-instance IsAllegraEraOnwards C.BabbageEra where
-   allegraEraOnwards = C.AllegraEraOnwardsBabbage
-
-instance IsAllegraEraOnwards C.ConwayEra where
-   allegraEraOnwards = C.AllegraEraOnwardsConway
-
--- | The class of eras that are after Mary.
--- TODO Move to cardano-api
-class C.IsCardanoEra era => IsMaryEraOnwards era where
-   maryEraOnwards :: C.MaryEraOnwards era
-
-instance IsMaryEraOnwards C.MaryEra where
-   maryEraOnwards = C.MaryEraOnwardsMary
-
-instance IsMaryEraOnwards C.AlonzoEra where
-   maryEraOnwards = C.MaryEraOnwardsAlonzo
-
-instance IsMaryEraOnwards C.BabbageEra where
-   maryEraOnwards = C.MaryEraOnwardsBabbage
-
-instance IsMaryEraOnwards C.ConwayEra where
-   maryEraOnwards = C.MaryEraOnwardsConway
-
-
--- | The class of eras that are after Alonzo.
--- TODO Move to cardano-api
-class C.IsCardanoEra era => IsAlonzoEraOnwards era where
-   alonzoEraOnwards :: C.AlonzoEraOnwards era
-
-instance IsAlonzoEraOnwards C.AlonzoEra where
-   alonzoEraOnwards = C.AlonzoEraOnwardsAlonzo
-
-instance IsAlonzoEraOnwards C.BabbageEra where
-   alonzoEraOnwards = C.AlonzoEraOnwardsBabbage
-
-instance IsAlonzoEraOnwards C.ConwayEra where
-   alonzoEraOnwards = C.AlonzoEraOnwardsConway
-
--- | The class of eras that are after babbage.
--- TODO Move to cardano-api
-class C.IsCardanoEra era => IsBabbageEraOnwards era where
-   babbageEraOnwards :: C.BabbageEraOnwards era
-
-instance IsBabbageEraOnwards C.BabbageEra where
-   babbageEraOnwards = C.BabbageEraOnwardsBabbage
-
-instance IsBabbageEraOnwards C.ConwayEra where
-   babbageEraOnwards = C.BabbageEraOnwardsConway
-
--- | The class of eras that are after conway.
--- TODO Move to cardano-api
-class C.IsCardanoEra era => IsConwayEraOnwards era where
-   conwayEraOnwards :: C.ConwayEraOnwards era
-
-instance IsConwayEraOnwards C.ConwayEra where
-   conwayEraOnwards = C.ConwayEraOnwardsConway
 
 {-| 'TxBodyContent' with all fields set to empty, none, default values
 TODO Remove and replace with C.defaultTxBodyContent
@@ -259,12 +183,12 @@ txIns = lens get set_ where
   get = C.txIns
   set_ body txIns' = body{C.txIns=txIns'}
 
-txInsReference :: Lens' (C.TxBodyContent v era) (C.TxInsReference v era)
+txInsReference :: Lens' (C.TxBodyContent v era) (C.TxInsReference era)
 txInsReference = lens get set_ where
   get = C.txInsReference
   set_ body txInsRef' = body{C.txInsReference = txInsRef'}
 
-txInsReferenceTxIns :: Getter (C.TxInsReference ctx era) [C.TxIn]
+txInsReferenceTxIns :: Getter (C.TxInsReference era) [C.TxIn]
 txInsReferenceTxIns = L.to get_ where
   get_ = \case
     C.TxInsReferenceNone  -> []
@@ -343,14 +267,14 @@ txCertificates = lens get set_ where
   get = C.txCertificates
   set_ body k = body{C.txCertificates = k}
 
-txCurrentTreasuryValue :: Lens' (C.TxBodyContent v era) (Maybe (C.Featured C.ConwayEraOnwards era Coin))
+txCurrentTreasuryValue :: Lens' (C.TxBodyContent v era) (Maybe (C.Featured C.ConwayEraOnwards era (Maybe Coin)))
 txCurrentTreasuryValue = lens get set_ where
   get = C.txCurrentTreasuryValue
   set_ body k = body{C.txCurrentTreasuryValue = k}
 
 txTreasuryDonation :: Lens' (C.TxBodyContent v era) (Maybe (C.Featured C.ConwayEraOnwards era Coin))
 txTreasuryDonation = lens get set_ where
-  get = C.txCurrentTreasuryValue
+  get = C.txTreasuryDonation
   set_ body k = body{C.txTreasuryDonation = k}
 
 txProposalProcedures :: Lens' (C.TxBodyContent v era) (Maybe (C.Featured C.ConwayEraOnwards era (C.TxProposalProcedures v era)))
@@ -363,14 +287,14 @@ txVotingProcedures = lens get set_ where
   get = C.txVotingProcedures
   set_ body k = body{C.txVotingProcedures = k}
 
-_TxExtraKeyWitnesses :: IsAlonzoEraOnwards era => Iso' (C.TxExtraKeyWitnesses era) [C.Hash C.PaymentKey]
+_TxExtraKeyWitnesses :: C.IsAlonzoBasedEra era => Iso' (C.TxExtraKeyWitnesses era) [C.Hash C.PaymentKey]
 _TxExtraKeyWitnesses = iso from to where
   from :: C.TxExtraKeyWitnesses era -> [C.Hash C.PaymentKey]
   from C.TxExtraKeyWitnessesNone      = []
   from (C.TxExtraKeyWitnesses _ keys) = keys
 
   to []   = C.TxExtraKeyWitnessesNone
-  to keys = C.TxExtraKeyWitnesses alonzoEraOnwards keys
+  to keys = C.TxExtraKeyWitnesses C.alonzoBasedEra keys
 
 _TxWithdrawals :: C.IsShelleyBasedEra era => Iso' (C.TxWithdrawals v era) [(C.StakeAddress, Coin, BuildTxWith v (C.Witness C.WitCtxStake era))]
 _TxWithdrawals = iso from to where
@@ -383,40 +307,40 @@ _TxWithdrawals = iso from to where
 
 _TxCertificates
   :: forall era. C.IsShelleyBasedEra era
-  => Iso' (C.TxCertificates BuildTx era) ([C.Certificate era], Map C.StakeCredential (C.Witness C.WitCtxStake era))
+  => Iso' (C.TxCertificates BuildTx era) ([C.Certificate era], [(C.StakeCredential, C.Witness C.WitCtxStake era)])
 _TxCertificates = iso from to where
-  from :: C.TxCertificates BuildTx era -> ([C.Certificate era], (Map C.StakeCredential (C.Witness C.WitCtxStake era)))
-  from C.TxCertificatesNone                     = ([], Map.empty)
+  from :: C.TxCertificates BuildTx era -> ([C.Certificate era], [(C.StakeCredential, C.Witness C.WitCtxStake era)])
+  from C.TxCertificatesNone                     = ([], [])
   from (C.TxCertificates _ x (C.BuildTxWith y)) = (x, y)
 
-  to :: ([C.Certificate era], Map C.StakeCredential (C.Witness C.WitCtxStake era)) -> C.TxCertificates BuildTx era
-  to ([], mp) | Map.null mp = C.TxCertificatesNone
-  to (x, y) = C.TxCertificates C.shelleyBasedEra x (C.BuildTxWith y)
+  to :: ([C.Certificate era], [(C.StakeCredential, C.Witness C.WitCtxStake era)]) -> C.TxCertificates BuildTx era
+  to ([], []) = C.TxCertificatesNone
+  to (x, y)   = C.TxCertificates C.shelleyBasedEra x (C.BuildTxWith y)
 
 txAuxScripts :: Lens' (C.TxBodyContent v era) (C.TxAuxScripts era)
 txAuxScripts = lens get set_ where
   get = C.txAuxScripts
   set_ body s = body{C.txAuxScripts=s}
 
-_TxAuxScripts :: IsAllegraEraOnwards era => Iso' (C.TxAuxScripts era) [C.ScriptInEra era]
+_TxAuxScripts :: C.IsAllegraBasedEra era => Iso' (C.TxAuxScripts era) [C.ScriptInEra era]
 _TxAuxScripts = iso from to where
   from :: C.TxAuxScripts era -> [C.ScriptInEra era]
   from = \case
     C.TxAuxScriptsNone -> []
     C.TxAuxScripts _ s -> s
   to s | null s = C.TxAuxScriptsNone
-       | otherwise = C.TxAuxScripts allegraEraOnwards s
+       | otherwise = C.TxAuxScripts C.allegraBasedEra s
 
 _TxMetadata :: C.IsShelleyBasedEra era => Iso' (C.TxMetadataInEra era) (Map Word64 C.TxMetadataValue)
 _TxMetadata = iso from to where
-  from :: C.TxMetadataInEra era -> (Map Word64 C.TxMetadataValue)
+  from :: C.TxMetadataInEra era -> Map Word64 C.TxMetadataValue
   from = \case
     C.TxMetadataNone                     -> Map.empty
     C.TxMetadataInEra _ (C.TxMetadata m) -> m
   to m | Map.null m = C.TxMetadataNone
        | otherwise  = C.TxMetadataInEra C.shelleyBasedEra (C.TxMetadata m)
 
-_TxInsCollateralIso :: IsAlonzoEraOnwards era => Iso' (C.TxInsCollateral era) [C.TxIn]
+_TxInsCollateralIso :: C.IsAlonzoBasedEra era => Iso' (C.TxInsCollateral era) [C.TxIn]
 _TxInsCollateralIso = iso from to where
   from :: C.TxInsCollateral era -> [C.TxIn]
   from = \case
@@ -424,9 +348,9 @@ _TxInsCollateralIso = iso from to where
     C.TxInsCollateral _ xs -> xs
   to = \case
     [] -> C.TxInsCollateralNone
-    xs -> C.TxInsCollateral alonzoEraOnwards xs
+    xs -> C.TxInsCollateral C.alonzoBasedEra xs
 
-_TxMintValue :: IsMaryEraOnwards era => Iso' (TxMintValue BuildTx era) (Value, Map PolicyId (ScriptWitness WitCtxMint era))
+_TxMintValue :: C.IsMaryBasedEra era => Iso' (TxMintValue BuildTx era) (Value, Map PolicyId (ScriptWitness WitCtxMint era))
 _TxMintValue = iso from to where
   from :: TxMintValue BuildTx era -> (Value, Map PolicyId (ScriptWitness WitCtxMint era))
   from = \case
@@ -434,17 +358,17 @@ _TxMintValue = iso from to where
     C.TxMintValue _ vl (C.BuildTxWith mp) -> (vl, mp)
   to (vl, mp)
     | Map.null mp && vl == mempty = C.TxMintNone
-    | otherwise                   = C.TxMintValue maryEraOnwards vl (C.BuildTxWith mp)
+    | otherwise                   = C.TxMintValue C.maryBasedEra vl (C.BuildTxWith mp)
 
-_TxInsReferenceIso :: IsBabbageEraOnwards era => Iso' (C.TxInsReference build era) [C.TxIn]
+_TxInsReferenceIso :: C.IsBabbageBasedEra era => Iso' (C.TxInsReference era) [C.TxIn]
 _TxInsReferenceIso = iso from to where
-  from :: C.TxInsReference build era -> [C.TxIn]
+  from :: C.TxInsReference era -> [C.TxIn]
   from = \case
     C.TxInsReferenceNone   -> []
     C.TxInsReference _ ins -> ins
   to = \case
     [] -> C.TxInsReferenceNone
-    xs -> C.TxInsReference babbageEraOnwards xs
+    xs -> C.TxInsReference C.babbageBasedEra xs
 
 _Value :: Iso' Value (Map AssetId Quantity)
 _Value = iso from to where
@@ -464,29 +388,29 @@ _TxOut = iso from to where
   from (C.TxOut addr vl dt rs) = (addr, vl, dt, rs)
   to (addr, vl, dt, rs) = C.TxOut addr vl dt rs
 
-_TxOutDatumHash :: forall ctx era. IsAlonzoEraOnwards era => Prism' (TxOutDatum ctx era) (C.Hash C.ScriptData)
+_TxOutDatumHash :: forall ctx era. C.IsAlonzoBasedEra era => Prism' (TxOutDatum ctx era) (C.Hash C.ScriptData)
 _TxOutDatumHash = prism' from to where
   to :: TxOutDatum ctx era -> Maybe (C.Hash C.ScriptData)
   to (C.TxOutDatumHash _ h) = Just h
   to _                      = Nothing
   from :: C.Hash C.ScriptData -> TxOutDatum ctx era
-  from h = C.TxOutDatumHash alonzoEraOnwards h
+  from h = C.TxOutDatumHash C.alonzoBasedEra h
 
-_TxOutDatumInTx :: forall era. IsAlonzoEraOnwards era => Prism' (TxOutDatum CtxTx era) C.HashableScriptData
+_TxOutDatumInTx :: forall era. C.IsAlonzoBasedEra era => Prism' (TxOutDatum CtxTx era) C.HashableScriptData
 _TxOutDatumInTx = prism' from to where
   to :: TxOutDatum CtxTx era -> Maybe C.HashableScriptData
   to (C.TxOutDatumInTx _ k) = Just k
   to _                      = Nothing
   from :: C.HashableScriptData -> TxOutDatum CtxTx era
-  from cd = C.TxOutDatumInTx alonzoEraOnwards cd
+  from cd = C.TxOutDatumInTx C.alonzoBasedEra cd
 
-_TxOutDatumInline :: forall ctx era. IsBabbageEraOnwards era => Prism' (TxOutDatum ctx era) C.HashableScriptData
+_TxOutDatumInline :: forall ctx era. C.IsBabbageBasedEra era => Prism' (TxOutDatum ctx era) C.HashableScriptData
 _TxOutDatumInline = prism' from to where
   to :: TxOutDatum ctx era -> Maybe C.HashableScriptData
   to (C.TxOutDatumInline _ k) = Just k
   to _                        = Nothing
   from :: C.HashableScriptData -> TxOutDatum ctx era
-  from cd = C.TxOutDatumInline babbageEraOnwards cd
+  from cd = C.TxOutDatumInline C.babbageBasedEra cd
 
 _ShelleyAddress :: C.IsShelleyBasedEra era => Prism' (C.AddressInEra era) (Shelley.Network, Credential.PaymentCredential StandardCrypto, Credential.StakeReference StandardCrypto)
 _ShelleyAddress = prism' from to where
@@ -551,12 +475,12 @@ _BuildTxWith = iso from to where
   to = C.BuildTxWith
 
 _TxOutValue
-  :: forall era. (C.IsShelleyBasedEra era, Core.Value (C.ShelleyLedgerEra era) ~ MaryValue StandardCrypto)
+  :: forall era. C.IsMaryBasedEra era
   => Iso' (TxOutValue era) Value
 _TxOutValue = iso from to where
   from = C.txOutValueToValue
   to :: Value -> TxOutValue era
-  to = C.TxOutValueShelleyBased C.shelleyBasedEra . C.toMaryValue
+  to = C.maryEraOnwardsConstraints @era C.maryBasedEra $ C.TxOutValueShelleyBased C.shelleyBasedEra . C.toMaryValue
 
 slot :: Lens' (LedgerEnv era) SlotNo
 slot = lens get set_ where
@@ -669,9 +593,9 @@ _TxValidityUpperBound = iso from to where
   to :: (C.ShelleyBasedEra era, Maybe SlotNo) -> C.TxValidityUpperBound era
   to (k, s) = C.TxValidityUpperBound k s
 
-_TxValidityFiniteRange :: (IsAllegraEraOnwards era, C.IsShelleyBasedEra era) => Prism' (C.TxValidityLowerBound era, C.TxValidityUpperBound era) (SlotNo, SlotNo)
+_TxValidityFiniteRange :: (C.IsAllegraBasedEra era, C.IsShelleyBasedEra era) => Prism' (C.TxValidityLowerBound era, C.TxValidityUpperBound era) (SlotNo, SlotNo)
 _TxValidityFiniteRange = prism' from to where
-  from (l, u) = (C.TxValidityLowerBound allegraEraOnwards l, C.TxValidityUpperBound C.shelleyBasedEra (Just u))
+  from (l, u) = (C.TxValidityLowerBound C.allegraBasedEra l, C.TxValidityUpperBound C.shelleyBasedEra (Just u))
   to = \case
     (C.TxValidityLowerBound _ l, C.TxValidityUpperBound _ (Just u)) -> Just (l, u)
     _                                                        -> Nothing

--- a/src/wallet/lib/Convex/Wallet.hs
+++ b/src/wallet/lib/Convex/Wallet.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE ViewPatterns       #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-deprecations #-} -- see https://github.com/j-mueller/sc-tools/issues/213
 {-| Primitive wallet
 -}
 module Convex.Wallet(

--- a/src/wallet/lib/Convex/Wallet.hs
+++ b/src/wallet/lib/Convex/Wallet.hs
@@ -128,14 +128,14 @@ parse = fmap Wallet . C.deserialiseFromBech32 (C.AsSigningKey C.AsPaymentKey)
 
 {-| Select Ada-only inputs that cover the given amount of lovelace
 -}
-selectAdaInputsCovering :: UtxoSet ctx era a -> C.Quantity -> Maybe (C.Quantity, [C.TxIn])
-selectAdaInputsCovering utxoSet target = selectAnyInputsCovering (onlyAda utxoSet) target
+selectAdaInputsCovering :: UtxoSet ctx a -> C.Quantity -> Maybe (C.Quantity, [C.TxIn])
+selectAdaInputsCovering utxoSet = selectAnyInputsCovering (onlyAda utxoSet)
 
 {-| Select Ada-only inputs that cover the given amount of lovelace
 -}
-selectAnyInputsCovering :: UtxoSet ctx era a -> C.Quantity -> Maybe (C.Quantity, [C.TxIn])
+selectAnyInputsCovering :: UtxoSet ctx a -> C.Quantity -> Maybe (C.Quantity, [C.TxIn])
 selectAnyInputsCovering UtxoSet{_utxos} (C.Quantity target) =
-  let append (C.Quantity total_, txIns) (txIn, C.TxOut _ (C.lovelaceToQuantity . C.selectLovelace . C.txOutValueToValue -> C.Quantity coin_) _ _) =
+  let append (C.Quantity total_, txIns) (txIn, C.InAnyCardanoEra _ (C.TxOut _ (C.lovelaceToQuantity . C.selectLovelace . C.txOutValueToValue -> C.Quantity coin_) _ _)) =
         (C.Quantity (total_ + coin_), txIn : txIns)
    in
      find (\(C.Quantity c, _) -> c >= target)
@@ -146,13 +146,13 @@ selectAnyInputsCovering UtxoSet{_utxos} (C.Quantity target) =
 {-| Select inputs that cover the given amount of non-Ada
 assets.
 -}
-selectMixedInputsCovering :: UtxoSet ctx era a -> [(C.AssetId, C.Quantity)] -> Maybe (C.Value, [C.TxIn])
+selectMixedInputsCovering :: UtxoSet ctx a -> [(C.AssetId, C.Quantity)] -> Maybe (C.Value, [C.TxIn])
 selectMixedInputsCovering UtxoSet{_utxos} xs =
   let append (vl, txIns) (vl', txIn) = (vl <> vl', txIn : txIns)
       coversTarget (candidateVl, _txIns) =
         all (\(assetId, quantity) -> C.selectAsset candidateVl assetId >= quantity) xs
       requiredAssets = foldMap (\(a, _) -> Set.singleton a) xs
-      relevantValue (txIn, C.TxOut _ (C.txOutValueToValue -> value) _ _) =
+      relevantValue (txIn, C.InAnyCardanoEra _ (C.TxOut _ (C.txOutValueToValue -> value) _ _)) =
         let providedAssets = foldMap (Set.singleton . fst) (C.valueToList value)
         in if Set.null (Set.intersection requiredAssets providedAssets)
           then Nothing

--- a/src/wallet/lib/Convex/Wallet/API.hs
+++ b/src/wallet/lib/Convex/Wallet/API.hs
@@ -10,8 +10,9 @@ module Convex.Wallet.API(
   startServer
 ) where
 
-import           Cardano.Api                     (CtxTx)
-import           Control.Concurrent.STM          (TVar, atomically, readTVar)
+import           Cardano.Api                     (ConwayEra, CtxTx,
+                                                  IsShelleyBasedEra)
+import           Control.Concurrent.STM          (TVar, readTVarIO)
 import           Control.Monad.IO.Class          (MonadIO (..))
 import           Convex.Utxos                    (UtxoSet)
 import           Convex.Wallet.WalletState       (WalletState, utxoSet)
@@ -24,31 +25,31 @@ import           Servant.Client                  (ClientEnv, client, runClientM)
 import           Servant.Client.Core.ClientError (ClientError)
 import           Servant.Server                  (Server, serve)
 
-type API =
+type API era =
   "healthcheck" :> Description "Is the server alive?" :> Get '[JSON] NoContent
-  :<|> "utxos" :> Get '[JSON] (UtxoSet CtxTx ())
+  :<|> "utxos" :> Get '[JSON] (UtxoSet CtxTx era ())
 
 {-| Call the "healthcheck" endpoint
 -}
 getHealth :: ClientEnv -> IO (Either ClientError NoContent)
 getHealth clientEnv = do
-  let healthcheck :<|> _ = client (Proxy @API)
+  let healthcheck :<|> _ = client (Proxy @(API ConwayEra))
   runClientM healthcheck clientEnv
 
 {-| Call the "utxos" endpoint
 -}
-getUTxOs :: ClientEnv -> IO (Either ClientError (UtxoSet CtxTx ()))
+getUTxOs :: forall era. IsShelleyBasedEra era => ClientEnv -> IO (Either ClientError (UtxoSet CtxTx era ()))
 getUTxOs clientEnv = do
-  let _ :<|> utxos = client (Proxy @API)
+  let _ :<|> utxos = client (Proxy @(API era))
   runClientM utxos clientEnv
 
-server :: TVar WalletState -> Server API
+server :: TVar (WalletState era) -> Server (API era)
 server walletState = health :<|> utxo
   where
     health = pure NoContent
-    utxo = liftIO (utxoSet <$> atomically (readTVar walletState))
+    utxo = liftIO (utxoSet <$> readTVarIO walletState)
 
-startServer :: TVar WalletState -> Int -> IO ()
+startServer :: forall era. IsShelleyBasedEra era => TVar (WalletState era) -> Int -> IO ()
 startServer walletState port =
-  let app = serve (Proxy @API) (server walletState)
+  let app = serve (Proxy @(API era)) (server walletState)
   in Warp.run port app

--- a/src/wallet/lib/Convex/Wallet/Cli.hs
+++ b/src/wallet/lib/Convex/Wallet/Cli.hs
@@ -86,7 +86,7 @@ showAddress Config{cardanoNodeConfigFile, cardanoNodeSocket} operatorConfig = do
 
 runWallet :: (MonadLog m, MonadError C.InitialLedgerStateError m, MonadIO m) => K.LogEnv -> Int -> Config -> OperatorConfigVerification -> m ()
 runWallet logEnv port Config{cardanoNodeConfigFile, cardanoNodeSocket, walletFile} operatorConfig = do
-  initialState <- fromMaybe WalletState.initialWalletState <$> liftIO (WalletState.readFromFile @C.ConwayEra walletFile)
+  initialState <- fromMaybe WalletState.initialWalletState <$> liftIO (WalletState.readFromFile walletFile)
   op <- liftIO (loadOperatorFilesVerification operatorConfig)
   logInfoS $ "Resuming from " <> show (WalletState.chainPoint initialState)
   logInfo (PrettyBalance $ WalletState.utxoSet initialState)

--- a/src/wallet/lib/Convex/Wallet/Cli.hs
+++ b/src/wallet/lib/Convex/Wallet/Cli.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 {-| CLI interface for a wallet
 -}
 module Convex.Wallet.Cli(
@@ -85,7 +86,7 @@ showAddress Config{cardanoNodeConfigFile, cardanoNodeSocket} operatorConfig = do
 
 runWallet :: (MonadLog m, MonadError C.InitialLedgerStateError m, MonadIO m) => K.LogEnv -> Int -> Config -> OperatorConfigVerification -> m ()
 runWallet logEnv port Config{cardanoNodeConfigFile, cardanoNodeSocket, walletFile} operatorConfig = do
-  initialState <- fromMaybe WalletState.initialWalletState <$> liftIO (WalletState.readFromFile walletFile)
+  initialState <- fromMaybe WalletState.initialWalletState <$> liftIO (WalletState.readFromFile @C.ConwayEra walletFile)
   op <- liftIO (loadOperatorFilesVerification operatorConfig)
   logInfoS $ "Resuming from " <> show (WalletState.chainPoint initialState)
   logInfo (PrettyBalance $ WalletState.utxoSet initialState)

--- a/src/wallet/lib/Convex/Wallet/Operator.hs
+++ b/src/wallet/lib/Convex/Wallet/Operator.hs
@@ -36,8 +36,7 @@ module Convex.Wallet.Operator(
   loadOperatorFilesVerification
 ) where
 
-import           Cardano.Api              (ConwayEra, CtxTx, PaymentCredential,
-                                           TxOut)
+import           Cardano.Api              (CtxTx, PaymentCredential, TxOut)
 import qualified Cardano.Api.Shelley      as C
 import           Convex.CardanoApi.Lenses (emptyTxOut)
 import           Convex.Class             (MonadBlockchain (queryNetworkId))
@@ -96,7 +95,7 @@ signTx = \case
 
 {-| Add a signature to the transaction
 -}
-signTxOperator :: Operator Signing -> C.Tx C.ConwayEra -> C.Tx C.ConwayEra
+signTxOperator :: C.IsShelleyBasedEra era => Operator Signing -> C.Tx era -> C.Tx era
 signTxOperator Operator{oPaymentKey} = signTx oPaymentKey
 
 {-| An entity that can match orders
@@ -155,18 +154,18 @@ operatorShelleyWitnessSigningKey Operator { oPaymentKey } =
 
 {-| An empty output locked by the operator's payment credential
 -}
-operatorReturnOutput :: MonadBlockchain m => Operator k -> m (TxOut CtxTx ConwayEra)
+operatorReturnOutput :: (MonadBlockchain era m, C.IsShelleyBasedEra era) => Operator k -> m (TxOut CtxTx era)
 operatorReturnOutput = returnOutputFor . operatorPaymentCredential
 
 {- An empty output locked by the payment credential
 -}
-returnOutputFor :: MonadBlockchain m => PaymentCredential -> m (TxOut ctx ConwayEra)
+returnOutputFor :: (MonadBlockchain era m, C.IsShelleyBasedEra era) => PaymentCredential -> m (TxOut ctx era)
 returnOutputFor cred = do
   addr <- C.makeShelleyAddress
     <$> queryNetworkId
     <*> pure cred
     <*> pure C.NoStakeAddress
-  pure $ emptyTxOut $ C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraConway) addr
+  pure $ emptyTxOut $ C.AddressInEra (C.ShelleyAddressInEra C.shelleyBasedEra) addr
 
 {-| Loading operator files for signing from disk
 -}

--- a/src/wallet/lib/Convex/Wallet/WalletState.hs
+++ b/src/wallet/lib/Convex/Wallet/WalletState.hs
@@ -25,37 +25,37 @@ import           Data.Aeson.Encode.Pretty   (encodePretty)
 import qualified Data.ByteString.Lazy       as BSL
 import           GHC.Generics               (Generic)
 
-data WalletState era =
+data WalletState =
   WalletState
     { wsChainPoint :: JSONChainPoint
-    , wsUtxos      :: UtxoSet C.CtxTx era ()
+    , wsUtxos      :: UtxoSet C.CtxTx ()
     }
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 {-| Construct a 'WalletState' from a UTxO set and a block header
 -}
-walletState :: UtxoSet C.CtxTx era () -> BlockHeader -> WalletState era
+walletState :: UtxoSet C.CtxTx () -> BlockHeader -> WalletState
 walletState wsUtxos (BlockHeader slot hsh _)=
   let wsChainPoint = JSONChainPoint $ ChainPoint slot hsh
   in WalletState{wsUtxos, wsChainPoint}
 
-chainPoint :: WalletState era -> ChainPoint
+chainPoint :: WalletState -> ChainPoint
 chainPoint WalletState{wsChainPoint = JSONChainPoint c} = c
 
-utxoSet :: WalletState era -> UtxoSet C.CtxTx era ()
+utxoSet :: WalletState -> UtxoSet C.CtxTx ()
 utxoSet WalletState{wsUtxos} = wsUtxos
 
-initialWalletState :: WalletState era
+initialWalletState :: WalletState
 initialWalletState = WalletState (JSONChainPoint lessRecent) mempty
 
 {-| Write the wallet state to a JSON file
 -}
-writeToFile :: C.IsCardanoEra era => FilePath -> WalletState era -> IO ()
+writeToFile :: FilePath -> WalletState -> IO ()
 writeToFile file = BSL.writeFile file . encodePretty
 
 {-| Read the wallet state from a JSON file
 -}
-readFromFile :: C.IsShelleyBasedEra era => FilePath -> IO (Maybe (WalletState era))
+readFromFile :: FilePath -> IO (Maybe WalletState)
 readFromFile fp =
   catch (decode <$> BSL.readFile fp) $ \(_ :: SomeException) -> pure Nothing

--- a/src/wallet/lib/Convex/Wallet/WalletState.hs
+++ b/src/wallet/lib/Convex/Wallet/WalletState.hs
@@ -25,37 +25,37 @@ import           Data.Aeson.Encode.Pretty   (encodePretty)
 import qualified Data.ByteString.Lazy       as BSL
 import           GHC.Generics               (Generic)
 
-data WalletState =
+data WalletState era =
   WalletState
     { wsChainPoint :: JSONChainPoint
-    , wsUtxos      :: UtxoSet C.CtxTx ()
+    , wsUtxos      :: UtxoSet C.CtxTx era ()
     }
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 {-| Construct a 'WalletState' from a UTxO set and a block header
 -}
-walletState :: UtxoSet C.CtxTx () -> BlockHeader -> WalletState
+walletState :: UtxoSet C.CtxTx era () -> BlockHeader -> WalletState era
 walletState wsUtxos (BlockHeader slot hsh _)=
   let wsChainPoint = JSONChainPoint $ ChainPoint slot hsh
   in WalletState{wsUtxos, wsChainPoint}
 
-chainPoint :: WalletState -> ChainPoint
+chainPoint :: WalletState era -> ChainPoint
 chainPoint WalletState{wsChainPoint = JSONChainPoint c} = c
 
-utxoSet :: WalletState -> UtxoSet C.CtxTx ()
+utxoSet :: WalletState era -> UtxoSet C.CtxTx era ()
 utxoSet WalletState{wsUtxos} = wsUtxos
 
-initialWalletState :: WalletState
+initialWalletState :: WalletState era
 initialWalletState = WalletState (JSONChainPoint lessRecent) mempty
 
 {-| Write the wallet state to a JSON file
 -}
-writeToFile :: FilePath -> WalletState -> IO ()
+writeToFile :: C.IsCardanoEra era => FilePath -> WalletState era -> IO ()
 writeToFile file = BSL.writeFile file . encodePretty
 
 {-| Read the wallet state from a JSON file
 -}
-readFromFile :: FilePath -> IO (Maybe WalletState)
+readFromFile :: C.IsShelleyBasedEra era => FilePath -> IO (Maybe (WalletState era))
 readFromFile fp =
   catch (decode <$> BSL.readFile fp) $ \(_ :: SomeException) -> pure Nothing


### PR DESCRIPTION
* Bump cardano-api to 9.3.0.0
* Remove hard-coded `ConwayEra` in most places, use constraints from `cardano-api`
* Update the `Scripts.MatchingIndex` example to use plutus v3

Thanks to @Swordlash for contributing a large part of the code