### PR TITLE
Add transaction building functions for correctly adding registration deregistration and delegation certificates in Conway era.

### DIFF
--- a/src/base/convex-base.cabal
+++ b/src/base/convex-base.cabal
@@ -31,6 +31,7 @@ library
       Convex.BuildTx
       Convex.Class
       Convex.Constants
+      Convex.Eon
       Convex.MonadLog
       Convex.NodeQueries
       Convex.NodeQueries.Debug

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -90,6 +90,7 @@ module Convex.BuildTx(
   addConwayStakeCredentialUnRegistrationCertificate,
   addStakeWitness,
   addStakeScriptWitness,
+  addStakeScriptWitnessRef,
   addStakeWitnessWithTxBody,
 
   -- ** Minting and burning tokens
@@ -350,7 +351,6 @@ addStakeWitness ::
 addStakeWitness credential witness =
   addBtx (over (L.txCertificates . L._TxCertificates . _2) ((:) (credential, witness)))
 
--- mintPlutus :: forall redeemer lang era m. (Plutus.ToData redeemer, MonadBuildTx era m, C.HasScriptLanguageInEra lang era, C.IsAlonzoBasedEra era, C.IsPlutusScriptLanguage lang) => PlutusScript lang -> redeemer -> C.AssetName -> C.Quantity -> m ()
 {-| Add a stake script witness to the transaction.
 -}
 addStakeScriptWitness ::
@@ -366,6 +366,24 @@ addStakeScriptWitness ::
   -> m ()
 addStakeScriptWitness credential script redeemer = do
   let scriptWitness = buildScriptWitness script C.NoScriptDatumForStake redeemer
+  let witness = C.ScriptWitness C.ScriptWitnessForStakeAddr scriptWitness
+  addBtx (over (L.txCertificates . L._TxCertificates . _2) ((:) (credential, witness)))
+
+{-| Add a stake script reference witness to the transaction.
+-}
+addStakeScriptWitnessRef ::
+  ( MonadBuildTx era m
+  , Plutus.ToData redeemer
+  , C.IsShelleyBasedEra era
+  , C.HasScriptLanguageInEra lang era
+  )
+  => C.StakeCredential
+  -> C.TxIn
+  -> C.PlutusScriptVersion lang
+  -> redeemer
+  -> m ()
+addStakeScriptWitnessRef credential txIn plutusScriptVersion redeemer = do
+  let scriptWitness = buildRefScriptWitness txIn plutusScriptVersion C.NoScriptDatumForStake redeemer
   let witness = C.ScriptWitness C.ScriptWitnessForStakeAddr scriptWitness
   addBtx (over (L.txCertificates . L._TxCertificates . _2) ((:) (credential, witness)))
 

--- a/src/base/lib/Convex/Eon.hs
+++ b/src/base/lib/Convex/Eon.hs
@@ -1,0 +1,26 @@
+module Convex.Eon (
+  IsShelleyToBabbageEra(shelleyToBabbageEra)
+) where
+
+import qualified Cardano.Api as C
+
+-- TODO This was deleted from cardano-api because they said it was unused. See
+-- https://github.com/IntersectMBO/cardano-api/pull/256. However, because of the
+-- Certificate type starting at ConwayEra, that typeclass is a nice to have.
+class C.IsShelleyBasedEra era => IsShelleyToBabbageEra era where
+  shelleyToBabbageEra :: C.ShelleyToBabbageEra era
+
+instance IsShelleyToBabbageEra C.ShelleyEra where
+  shelleyToBabbageEra = C.ShelleyToBabbageEraShelley
+
+instance IsShelleyToBabbageEra C.AllegraEra where
+  shelleyToBabbageEra = C.ShelleyToBabbageEraAllegra
+
+instance IsShelleyToBabbageEra C.MaryEra where
+  shelleyToBabbageEra = C.ShelleyToBabbageEraMary
+
+instance IsShelleyToBabbageEra C.AlonzoEra where
+  shelleyToBabbageEra = C.ShelleyToBabbageEraAlonzo
+
+instance IsShelleyToBabbageEra C.BabbageEra where
+  shelleyToBabbageEra = C.ShelleyToBabbageEraBabbage

--- a/src/base/test/Convex/PlutusLedgerSpec.hs
+++ b/src/base/test/Convex/PlutusLedgerSpec.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GADTs              #-}
 
 module Convex.PlutusLedgerSpec where
 
-import qualified Cardano.Api.Shelley as C
-import Test.Gen.Cardano.Api.Typed qualified as CGen
-import Convex.PlutusLedger (transAddressShelley, unTransAddressShelley)
-import Test.QuickCheck qualified as QC
-import Test.QuickCheck.Hedgehog qualified as QC
-import qualified Cardano.Api.Ledger as Shelley
+import qualified Cardano.Api.Ledger         as Shelley
+import qualified Cardano.Api.Shelley        as C
+import           Convex.PlutusLedger        (transAddressShelley,
+                                             unTransAddressShelley)
+import qualified Test.Gen.Cardano.Api.Typed as CGen
+import qualified Test.QuickCheck            as QC
+import qualified Test.QuickCheck.Hedgehog   as QC
 
 newtype ArbitraryNetworkMagic = ArbitraryNetworkMagic C.NetworkMagic
   deriving stock (Show)
@@ -29,5 +30,5 @@ prop_rountripAddressShelleyPlutusTranslation
   = do
   let nid = case n of Shelley.Mainnet -> C.Mainnet; Shelley.Testnet -> C.Testnet nm
   case unTransAddressShelley nid (transAddressShelley addr) of
-    Left _err -> False
+    Left _err   -> False
     Right addr' -> addr' == addr

--- a/src/coin-selection/convex-coin-selection.cabal
+++ b/src/coin-selection/convex-coin-selection.cabal
@@ -54,6 +54,7 @@ library
     -- cardano dependencies
     build-depends:
       cardano-api,
+      cardano-ledger-api,
       cardano-ledger-core -any,
       cardano-ledger-shelley,
       cardano-slotting,
@@ -78,7 +79,6 @@ test-suite convex-coin-selection-test
     QuickCheck,
     lens,
     cardano-ledger-api,
-    cardano-ledger-core,
     cardano-ledger-conway,
     cardano-ledger-shelley,
     convex-coin-selection,

--- a/src/devnet/config/devnet/genesis-shelley.json
+++ b/src/devnet/config/devnet/genesis-shelley.json
@@ -28,7 +28,7 @@
         "minPoolCost": 0,
         "minUTxOValue": 0,
         "nOpt": 100,
-        "poolDeposit": 0,
+        "poolDeposit": 500000000,
         "protocolVersion": {
             "major": 10,
             "minor": 0

--- a/src/devnet/lib/Convex/Devnet/Wallet.hs
+++ b/src/devnet/lib/Convex/Devnet/Wallet.hs
@@ -23,8 +23,6 @@ module Convex.Devnet.Wallet(
   runningNodeBlockchain
 ) where
 
-import           Cardano.Api                     (AddressInEra,
-                                                  Quantity, Tx)
 import qualified Cardano.Api                     as C
 import           Control.Monad                   (replicateM)
 import           Control.Monad.IO.Class          (MonadIO (..))
@@ -64,7 +62,7 @@ walletUtxos RunningNode{rnConnectInfo, rnNetworkId} wllt =
 
 {-| Send @n@ times the given amount of lovelace to the address
 -}
-sendFaucetFundsTo :: forall era. C.IsBabbageBasedEra era => Tracer IO WalletLog -> RunningNode -> AddressInEra era -> Int -> Quantity -> IO (Tx era)
+sendFaucetFundsTo :: forall era. C.IsBabbageBasedEra era => Tracer IO WalletLog -> RunningNode -> C.AddressInEra era -> Int -> C.Quantity -> IO (C.Tx era)
 sendFaucetFundsTo tracer node destination n amount = do
   fct <- faucet
   balanceAndSubmit tracer node fct (BuildTx.execBuildTx $ replicateM n (BuildTx.payToAddress destination (C.lovelaceToValue $ C.quantityToLovelace amount))) TrailingChange []
@@ -72,7 +70,7 @@ sendFaucetFundsTo tracer node destination n amount = do
 {-| Create a new wallet and send @n@ times the given amount of lovelace to it. Returns when the seed txn has been registered
 on the chain.
 -}
-createSeededWallet :: forall era. C.IsBabbageBasedEra era => C.BabbageEraOnwards era -> Tracer IO WalletLog -> RunningNode -> Int -> Quantity -> IO Wallet
+createSeededWallet :: forall era. C.IsBabbageBasedEra era => C.BabbageEraOnwards era -> Tracer IO WalletLog -> RunningNode -> Int -> C.Quantity -> IO Wallet
 createSeededWallet _babbageEraOnwards tracer node@RunningNode{rnNetworkId, rnConnectInfo} n amount = do
   wallet <- Wallet.generateWallet
   traceWith tracer (GeneratedWallet wallet)
@@ -93,7 +91,7 @@ runningNodeBlockchain tracer RunningNode{rnConnectInfo} =
 
 {-| Balance and submit the transaction using the wallet's UTXOs
 -}
-balanceAndSubmit :: forall era. C.IsBabbageBasedEra era => Tracer IO WalletLog -> RunningNode -> Wallet -> TxBuilder era -> ChangeOutputPosition -> [C.ShelleyWitnessSigningKey] -> IO (Tx era)
+balanceAndSubmit :: forall era. C.IsBabbageBasedEra era => Tracer IO WalletLog -> RunningNode -> Wallet -> TxBuilder era -> ChangeOutputPosition -> [C.ShelleyWitnessSigningKey] -> IO (C.Tx era)
 balanceAndSubmit tracer node wallet tx changePosition keys = do
   n <- runningNodeBlockchain @era tracer node queryNetworkId
   let walletAddress = Wallet.addressInEra n wallet
@@ -112,7 +110,7 @@ balanceAndSubmitReturn
   -> TxBuilder era
   -> ChangeOutputPosition
   -> [C.ShelleyWitnessSigningKey]
-  -> IO (Tx era)
+  -> IO (C.Tx era)
 balanceAndSubmitReturn tracer node wallet returnOutput tx changePosition keys = do
   utxos <- walletUtxos node wallet
   runningNodeBlockchain tracer node $ do

--- a/src/devnet/test/Spec.hs
+++ b/src/devnet/test/Spec.hs
@@ -115,7 +115,7 @@ checkTransitionToConway = do
           Queries.queryEra rnConnectInfo >>= assertEqual "Should be in conway era" (C.anyCardanoEra C.ConwayEra)
           let lovelacePerUtxo = 100_000_000
               numUtxos        = 10
-          void $ W.createSeededWallet (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
+          void $ W.createSeededWallet C.BabbageEraOnwardsConway (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
           majorProtVersionsRef <- newIORef []
           res <- C.liftIO $ runExceptT $ runNodeClient rnNodeConfigFile rnNodeSocket $ \_localNodeConnectInfo env -> do
             pure $ foldClient () NoLedgerStateArgs env $ \_catchingUp _ _ bim -> do
@@ -146,7 +146,7 @@ startLocalStakePoolNode = do
           let lovelacePerUtxo = 100_000_000
               numUtxos        = 10
               nodeConfigFile  = tmp </> "cardano-node.json"
-          wllt <- W.createSeededWallet (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
+          wllt <- W.createSeededWallet C.BabbageEraOnwardsConway (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
           withTempDir "cardano-cluster-stakepool" $ \tmp' -> do
             withCardanoStakePoolNodeDevnetConfig (contramap TLNode tr) tmp' wllt defaultStakePoolNodeParams nodeConfigFile (PortsConfig 3002 [3001]) runningNode $ \RunningStakePoolNode{rspnNode} -> do
               runExceptT (loadConnectInfo (rnNodeConfigFile rspnNode) (rnNodeSocket rspnNode)) >>= \case
@@ -162,7 +162,7 @@ registeredStakePoolNode = do
           let lovelacePerUtxo = 100_000_000
               numUtxos        = 10
               nodeConfigFile  = tmp </> "cardano-node.json"
-          wllt <- W.createSeededWallet (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
+          wllt <- W.createSeededWallet C.BabbageEraOnwardsConway (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
           initialStakePools <- queryStakePools rnConnectInfo
           withTempDir "cardano-cluster-stakepool" $ \tmp' -> do
             withCardanoStakePoolNodeDevnetConfig (contramap TLNode tr) tmp' wllt defaultStakePoolNodeParams nodeConfigFile (PortsConfig 3002 [3001])  runningNode $ \_ -> do
@@ -181,7 +181,7 @@ stakePoolRewards = do
           let lovelacePerUtxo = 10_000_000_000
               numUtxos        = 4
               nodeConfigFile  = tmp </> "cardano-node.json"
-          wllt <- W.createSeededWallet (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
+          wllt <- W.createSeededWallet C.BabbageEraOnwardsConway (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
           let stakepoolParams = StakePoolNodeParams
                                   { spnCost   = 340_000_000
                                   , spnMargin = 1 % 100
@@ -232,7 +232,7 @@ makePayment = do
         withCardanoNodeDevnet (contramap TLNode tr) tmp $ \runningNode -> do
           let lovelacePerUtxo = 100_000_000
               numUtxos        = 10
-          wllt <- W.createSeededWallet (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
+          wllt <- W.createSeededWallet C.BabbageEraOnwardsConway (contramap TLWallet tr) runningNode numUtxos lovelacePerUtxo
           bal <- Utxos.totalBalance <$> W.walletUtxos runningNode wllt
           assertEqual "Wallet should have the expected balance" (fromIntegral numUtxos * lovelacePerUtxo) (C.lovelaceToQuantity $ C.selectLovelace bal)
 

--- a/src/mockchain/lib/Convex/MockChain/Defaults.hs
+++ b/src/mockchain/lib/Convex/MockChain/Defaults.hs
@@ -105,7 +105,9 @@ protocolParameters =
           & L.hkdMaxTxSizeL .~ 16_384
           & L.hkdMinFeeAL .~ 44
           & L.hkdMinFeeBL .~ 155_381
+          & L.hkdKeyDepositL .~ 2_000_000
           & L.hkdPoolDepositL .~ 500_000_000
+          & L.hkdDRepDepositL .~ 500_000_000
           & L.hkdCoinsPerUTxOByteL .~ L.CoinPerByte 4_310
           & L.hkdPricesL .~ L.Prices
               { L.prMem   = C.unsafeBoundedRational (577 % 10_000)


### PR DESCRIPTION
Add transaction building functions for correctly adding registration deregistration and delegation certificates in Conway era.

* Add functions for adding certificates in transactions such as:
    * `addShelleyStakeCredentialRegistrationCertificatePreConway`
    * `addShelleyStakeCredentialUnregistrationCertificatePreConway`
    * `addShelleyStakeCredentialRegistrationCertificateInConway`
    * `addShelleyStakeCredentialUnregistrationCertificateInConway`
    * `addConwayStakeCredentialRegistrationCertificate`
    * `addConwayStakeCredentialRegistrationAndDelegationCertificate`
    * `addConwayStakeCredentialDeRegistrationCertificate`

* Add `addStakeScriptWitness` which adds a script stake address witness
  in the transaction. This is a simplified version of `addStakeWitness`.

* Add Convex.Eon.IsShelleyToBabbageEra typeclass for building
  certificates in pre-conway eras.

* Modifies mockchain and devnet protocol parameter default values to
  reflect actual certificate deposits in current mainnet.
    * A stake address registration requires 20_000_000 lovelace as
      deposit.
    * A stake pool certification requires 500_000_000 lovelace as
      deposit.

* Fix tests given new Conway rules for:
    * registering stake address
    * registering stake pool
    * delegating to stake pools and DReps
    * withdrawal zero trick

* Change signature of unTransAddressInEra, transAddressInEra, unTransTxOutValue, unTransTxOutDatumHash to work with any era

* Change signature of sendFaucetFundsTo, createSeededWallet, balanceAndSubmit, balanceAndSubmitReturn to work with any era