### PR TITLE
Bumps the version of upload-pages-artifact to 3.0.1

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -40,7 +40,7 @@ jobs:
           cabal haddock-project --local --output=haddocks
 
       - name: Upload GH pages artifact
-        uses: actions/upload-pages-artifact@v2.0.0
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: haddocks
 


### PR DESCRIPTION
* Fixes the deprecation failure on github