### PR TITLE
Update Nix version in CI, and add cachix substituters in `flake.nix`.

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.ref }}-cabal
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -5,14 +5,14 @@ on:
     branches: [ "main" ]
     tags: [ "*.*.*" ]
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.ref }}-nix
   cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v25
+    - uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v15

--- a/flake.nix
+++ b/flake.nix
@@ -47,9 +47,11 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.iog.io"
+      "https://sc-tools.cachix.org"
     ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      "sc-tools.cachix.org-1:DY2+6v0HuMvoCt7wEqZTPqzZBcNk/Lexb72Vixz6n6I="
     ];
     allow-import-from-derivation = true;
   };

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -4,9 +4,6 @@ let
   sha256map = {
   };
 
-  cardano-node = inputs.cardano-node.packages.cardano-node;
-  cardano-cli = inputs.cardano-cli.legacyPackages.cardano-cli;
-
   modules = [
     ({ config, ... }: {
       packages = {


### PR DESCRIPTION
Allow to fetch derivation from cachix when available.

* Add substituers in `flake.nix`
* Update Nix to the latest version
* Difference concurrency Github action group between cabal run, and Nix run. Before, the same name name resulted in a conflict which prevented the Nix run to execute, thus the derivations would not be available in the Nix store.