### PR TITLE
Add queryStakeVoteDelegatees in MonadBlockchain

### DIFF
--- a/src/blockfrost/lib/Convex/Blockfrost.hs
+++ b/src/blockfrost/lib/Convex/Blockfrost.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -107,8 +105,9 @@ instance (MonadIO m) => MonadBlockchain C.ConwayEra (BlockfrostT m) where
   sendTx = MonadBlockchain.sendTxBlockfrost
   utxoByTxIn = BlockfrostT . MonadBlockchain.getUtxoByTxIn
   queryProtocolParameters = BlockfrostT MonadBlockchain.getProtocolParams
-  queryStakeAddresses s _ = BlockfrostT (MonadBlockchain.getStakeAddresses s)
+  queryStakeAddresses stakeCreds _ = BlockfrostT (MonadBlockchain.getStakeAddresses stakeCreds)
   queryStakePools = BlockfrostT MonadBlockchain.getStakePools
+  queryStakeVoteDelegatees stakeCreds = BlockfrostT (MonadBlockchain.getStakeVoteDelegatees stakeCreds)
   querySystemStart = BlockfrostT MonadBlockchain.getSystemStart
   queryEraHistory = BlockfrostT MonadBlockchain.getEraHistory
   querySlotNo = BlockfrostT MonadBlockchain.getSlotNo

--- a/src/blockfrost/lib/Convex/Blockfrost/MonadBlockchain.hs
+++ b/src/blockfrost/lib/Convex/Blockfrost/MonadBlockchain.hs
@@ -201,6 +201,7 @@ getStakePools = do
 -- Get the DRep votes for a set of stake credentials.
 --
 -- TODO To implement. Current blockfrost-haskell API doesn't support it.
+-- See `https://github.com/blockfrost/blockfrost-haskell/issues/76`.
 getStakeVoteDelegatees :: Set C.StakeCredential -> m (Map C.StakeCredential (Ledger.DRep Ledger.StandardCrypto))
 getStakeVoteDelegatees _stakeCredentials = error "NOT IMPLEMENTED YET."
 

--- a/src/blockfrost/lib/Convex/Blockfrost/MonadBlockchain.hs
+++ b/src/blockfrost/lib/Convex/Blockfrost/MonadBlockchain.hs
@@ -18,6 +18,7 @@ module Convex.Blockfrost.MonadBlockchain (
   getProtocolParams,
   getStakeAddresses,
   getStakePools,
+  getStakeVoteDelegatees,
   getSystemStart,
   getEraHistory,
   getSlotNo,
@@ -47,6 +48,7 @@ import Cardano.Api (
   fromNetworkMagic,
   serialiseToCBOR,
  )
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley (
   CtxUTxO,
   LedgerProtocolParameters (..),
@@ -195,6 +197,12 @@ getStakePools = do
   checkCurrentEpoch
   getOrRetrieve stakePools $
     Set.fromList . fmap Types.poolId <$> S.toList_ (Types.pagedStream $ \page -> Client.listPools' page Ascending)
+
+-- Get the DRep votes for a set of stake credentials.
+--
+-- TODO To implement. Current blockfrost-haskell API doesn't support it.
+getStakeVoteDelegatees :: Set C.StakeCredential -> m (Map C.StakeCredential (Ledger.DRep Ledger.StandardCrypto))
+getStakeVoteDelegatees _stakeCredentials = error "NOT IMPLEMENTED YET."
 
 -- | Send a transaction to the network using blockfrost's API
 sendTxBlockfrost :: (MonadBlockfrost m) => Tx ConwayEra -> m (Either (ValidationError ConwayEra) TxId)

--- a/src/devnet/test/Spec.hs
+++ b/src/devnet/test/Spec.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Main where
 


### PR DESCRIPTION
* Update `instance MonadBlockchain MockchainT`

* Update `instance MonadBlockchain BlockfrostT`: throws error because the Blockfrost Haskell API doesn't support querying stake addresses DRep voting.