### PR TITLE
Clarify the sendTx error situation in the types

### DIFF
--- a/src/blockfrost/convex-blockfrost.cabal
+++ b/src/blockfrost/convex-blockfrost.cabal
@@ -68,6 +68,7 @@ library
     , ouroboros-consensus-cardano
     , ouroboros-network-api
     , safe-money
+    , servant-client
     , sop-extras
     , streaming
     , text

--- a/src/coin-selection/lib/Convex/Query.hs
+++ b/src/coin-selection/lib/Convex/Query.hs
@@ -46,7 +46,7 @@ import Convex.BuildTx (TxBuilder)
 import Convex.Class (
   MonadBlockchain (..),
   MonadUtxoQuery (utxosByPaymentCredentials),
-  ValidationError (..),
+  SendTxError (..),
   utxosByPaymentCredential,
  )
 import Convex.CoinSelection (
@@ -180,7 +180,7 @@ selectOperatorUTxO operator = fmap listToMaybe (operatorUtxos operator)
 -- | Failures during txn balancing and submission
 data BalanceAndSubmitError era
   = BalanceError (BalanceTxError era)
-  | SubmitError (ValidationError era)
+  | SubmitError (SendTxError era)
   deriving stock (Show, Generic)
 
 makeClassyPrisms ''BalanceAndSubmitError

--- a/src/coin-selection/test/Spec.hs
+++ b/src/coin-selection/test/Spec.hs
@@ -52,6 +52,7 @@ import Convex.CoinSelection (
   publicKeyCredential,
  )
 import Convex.MockChain (
+  SendTxError (..),
   ValidationError (..),
   evalMockchain0IO,
   failedTransactions,
@@ -323,7 +324,7 @@ checkTxById = do
 {- | Build a transaction, then balance and sign it with the wallet, then
   submit it to the mockchain.
 -}
-execBuildTxWallet :: (MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m) => Wallet -> BuildTxT C.ConwayEra m a -> m (Either (ValidationError C.ConwayEra) C.TxId)
+execBuildTxWallet :: (MonadMockchain C.ConwayEra m, MonadError (BalanceTxError C.ConwayEra) m) => Wallet -> BuildTxT C.ConwayEra m a -> m (Either (SendTxError C.ConwayEra) C.TxId)
 execBuildTxWallet wallet action = do
   tx <- execBuildTxT (action >> setMinAdaDepositAll Defaults.bundledProtocolParameters)
   fmap (C.getTxId . C.getTxBody) <$> balanceAndSubmit mempty wallet tx TrailingChange []

--- a/src/devnet/lib/Convex/Devnet/Wallet.hs
+++ b/src/devnet/lib/Convex/Devnet/Wallet.hs
@@ -34,7 +34,7 @@ import Convex.BuildTx qualified as BuildTx
 import Convex.CardanoApi.Lenses (emptyTxOut)
 import Convex.Class (
   MonadBlockchain (queryNetworkId),
-  ValidationError,
+  SendTxError,
   runMonadBlockchainCardanoNodeT,
   sendTx,
  )
@@ -66,7 +66,7 @@ walletUtxos RunningNode{rnConnectInfo, rnNetworkId} wllt =
   NodeQueries.queryUTxOByAddress rnConnectInfo [C.toAddressAny $ address rnNetworkId wllt]
 
 -- | Send @n@ times the given amount of lovelace to the address
-sendFaucetFundsTo :: forall era. (C.IsBabbageBasedEra era) => Tracer IO WalletLog -> RunningNode -> C.AddressInEra era -> Int -> C.Quantity -> IO (Either (ValidationError era) (C.Tx era))
+sendFaucetFundsTo :: forall era. (C.IsBabbageBasedEra era) => Tracer IO WalletLog -> RunningNode -> C.AddressInEra era -> Int -> C.Quantity -> IO (Either (SendTxError era) (C.Tx era))
 sendFaucetFundsTo tracer node destination n amount = do
   fct <- faucet
   balanceAndSubmit tracer node fct (BuildTx.execBuildTx $ replicateM n (BuildTx.payToAddress destination (C.lovelaceToValue $ C.quantityToLovelace amount))) TrailingChange []
@@ -107,7 +107,7 @@ balanceAndSubmit
   -> TxBuilder era
   -> ChangeOutputPosition
   -> [C.ShelleyWitnessSigningKey]
-  -> IO (Either (ValidationError era) (C.Tx era))
+  -> IO (Either (SendTxError era) (C.Tx era))
 balanceAndSubmit tracer node wallet tx changePosition keys = do
   n <- runningNodeBlockchain @era tracer node queryNetworkId
   let walletAddress = Wallet.addressInEra n wallet
@@ -125,7 +125,7 @@ balanceAndSubmitReturn
   -> TxBuilder era
   -> ChangeOutputPosition
   -> [C.ShelleyWitnessSigningKey]
-  -> IO (Either (ValidationError era) (C.Tx era))
+  -> IO (Either (SendTxError era) (C.Tx era))
 balanceAndSubmitReturn tracer node wallet returnOutput tx changePosition keys = do
   utxos <- walletUtxos node wallet
   runningNodeBlockchain tracer node $ do

--- a/src/maestro/lib/Convex/Maestro/MonadBlockchain.hs
+++ b/src/maestro/lib/Convex/Maestro/MonadBlockchain.hs
@@ -24,7 +24,7 @@ import Cardano.Api qualified as C
 import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Slotting.Time (SlotLength, SystemStart)
 import Control.Monad.Trans.Class (lift)
-import Convex.Class (ValidationError)
+import Convex.Class (SendTxError)
 import Convex.Maestro.Types qualified as CMTypes
 import Convex.Utils (
   slotToUtcTime,
@@ -61,7 +61,7 @@ import Streaming.Prelude (Of, Stream)
 import Streaming.Prelude qualified as S
 
 -- | Submit a transaction (not yet supported by Maestro SDK)
-sendTxMaestro :: Bool -> Env.MaestroEnv 'Env.V1 -> C.Tx C.ConwayEra -> IO (Either (ValidationError CMTypes.CurrentEra) C.TxId)
+sendTxMaestro :: Bool -> Env.MaestroEnv 'Env.V1 -> C.Tx C.ConwayEra -> IO (Either (SendTxError CMTypes.CurrentEra) C.TxId)
 sendTxMaestro turboFlag env tx = do
   let txCbor = C.serialiseToCBOR tx
   CMTypes.maestroSubmitResult

--- a/src/maestro/lib/Convex/Maestro/Types.hs
+++ b/src/maestro/lib/Convex/Maestro/Types.hs
@@ -51,7 +51,7 @@ import Cardano.Ledger.Plutus.Language qualified as Plutus.Language
 import Cardano.Slotting.Slot qualified as CSlot
 import Cardano.Slotting.Time qualified as CTime
 import Control.Lens
-import Convex.Class (ValidationError)
+import Convex.Class (SendTxError (OtherProviderError))
 import Data.Bifunctor (first)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
@@ -87,11 +87,11 @@ poolId (Bech32StringOf text) =
 toMaestroTxIn :: C.TxIn -> OutputReference
 toMaestroTxIn (C.TxIn txId (C.TxIx txIx)) = OutputReference (TxHash (C.serialiseToRawBytesHexText txId)) (fromIntegral txIx)
 
-maestroSubmitResult :: Text.Text -> Either (ValidationError CurrentEra) C.TxId
+maestroSubmitResult :: Text.Text -> Either (SendTxError CurrentEra) C.TxId
 maestroSubmitResult submitResult = either (const (mapToValidationError submitResult)) Right . C.deserialiseFromRawBytesHex . Text.Encoding.encodeUtf8 $ submitResult
  where
-  mapToValidationError :: Text.Text -> Either (ValidationError CurrentEra) C.TxId
-  mapToValidationError = Left . error . show
+  mapToValidationError :: Text.Text -> Either (SendTxError CurrentEra) C.TxId
+  mapToValidationError = Left . OtherProviderError
 
 toMaestroStakeAddress :: C.StakeAddress -> Maestro.Bech32StringOf Maestro.RewardAddress
 toMaestroStakeAddress = Maestro.Bech32StringOf . C.serialiseToBech32

--- a/src/mockchain/lib/Convex/MockChain.hs
+++ b/src/mockchain/lib/Convex/MockChain.hs
@@ -31,6 +31,8 @@ module Convex.MockChain (
   ExUnitsError (..),
   _Phase1Error,
   _Phase2Error,
+  SendTxError (..),
+  _MockchainError,
   ValidationError (..),
   _VExUnits,
   _PredicateFailures,
@@ -179,6 +181,7 @@ import Convex.Class (
   MonadDatumQuery (..),
   MonadMockchain (..),
   MonadUtxoQuery (..),
+  SendTxError (..),
   ValidationError (..),
   datums,
   env,
@@ -188,6 +191,7 @@ import Convex.Class (
   transactions,
   txById,
   _ApplyTxFailure,
+  _MockchainError,
   _Phase1Error,
   _Phase2Error,
   _PredicateFailures,
@@ -454,7 +458,7 @@ instance (Monad m, C.IsConwayBasedEra era, C.IsEra era, EraStake (C.ShelleyLedge
     case applyTransaction nps st tx of
       Left err -> do
         failedTransactions %= ((tx, err) :)
-        return $ Left err
+        return $ Left $ MockchainError err
       Right (st', _) -> do
         let C.Tx body _ = tx
             i = C.getTxId body


### PR DESCRIPTION
This PR fixes that sendTx errors from Blockfrost and Maestro were not returned in the Left of the Either but instead thrown. 

Also it clarifies that VExUnits, PredicateFailures and ApplyTxFailure cases only happen for the Mockchain implementation.

(And fixes #271)