### PR TITLE
Testing interface support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ download-tx-test.sh
 tx.json
 graph.dot
 .vim
+tmp/
+*.ignore.*

--- a/src/base/lib/Convex/BuildTx.hs
+++ b/src/base/lib/Convex/BuildTx.hs
@@ -53,6 +53,7 @@ module Convex.BuildTx (
   addOutput,
   setScriptsValid,
   addRequiredSignature,
+  addValidityRangeSlots,
 
   -- ** Variations of @addInput@
   spendPublicKeyOutput,
@@ -77,6 +78,7 @@ module Convex.BuildTx (
   payToScriptHash,
   payToScriptDatumHash,
   payToScriptInlineDatum,
+  payToScriptInlineDatumWithRef,
   createRefScriptBase,
   createRefScriptNoDatum,
   createRefScriptDatumHash,
@@ -843,6 +845,16 @@ payToScriptInlineDatum network sh datum stakeRef vl =
         txo = C.TxOut addr val dat C.ReferenceScriptNone
      in addOutput txo
 
+payToScriptInlineDatumWithRef :: forall a era lang m. (MonadBuildTx era m, Plutus.ToData a, C.IsBabbageBasedEra era, C.IsScriptLanguage lang) => NetworkId -> C.ScriptHash -> a -> C.StakeAddressReference -> C.Value -> C.Script lang -> m ()
+payToScriptInlineDatumWithRef network sh datum stakeRef vl script =
+  inBabbage @era $
+    let val = mkTxOutValue vl
+        addr = C.makeShelleyAddressInEra C.shelleyBasedEra network (C.PaymentCredentialByScript sh) stakeRef
+        dat = C.TxOutDatumInline C.babbageBasedEra (toHashableScriptData datum)
+        refScript = C.ReferenceScript C.babbageBasedEra $ C.ScriptInAnyLang C.scriptLanguage script
+        txo = C.TxOut addr val dat refScript
+     in addOutput txo
+
 -- TODO: Functions for building outputs (Output -> Output)
 
 setScriptsValid :: (C.IsAlonzoBasedEra era) => (MonadBuildTx era m) => m ()
@@ -872,6 +884,13 @@ minAdaDeposit (C.LedgerProtocolParameters params) txOut =
 -- | Apply 'setMinAdaDeposit' to all outputs
 setMinAdaDepositAll :: (MonadBuildTx era m, C.IsMaryBasedEra era) => C.LedgerProtocolParameters era -> m ()
 setMinAdaDepositAll params = addBtx $ over (L.txOuts . mapped) (setMinAdaDeposit params)
+
+-- | Add a validity range to the transaction using slot numbers.
+addValidityRangeSlots :: (MonadBuildTx era m, C.IsAlonzoBasedEra era) => C.SlotNo -> C.SlotNo -> m ()
+addValidityRangeSlots lower upper =
+  addBtx $
+    C.setTxValidityLowerBound (C.TxValidityLowerBound C.allegraBasedEra lower)
+      . C.setTxValidityUpperBound (C.TxValidityUpperBound C.shelleyBasedEra (Just upper))
 
 -- | Add a public key hash to the list of required signatures.
 addRequiredSignature :: (MonadBuildTx era m, C.IsAlonzoBasedEra era) => Hash PaymentKey -> m ()

--- a/src/base/lib/Convex/Class.hs
+++ b/src/base/lib/Convex/Class.hs
@@ -29,6 +29,7 @@ module Convex.Class (
   MockChainState (..),
   env,
   poolState,
+  coverageData,
   transactions,
   failedTransactions,
   datums,
@@ -165,6 +166,7 @@ import Ouroboros.Consensus.HardFork.History (
 import Ouroboros.Network.Protocol.LocalStateQuery.Type qualified as T
 import Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))
 import PlutusLedgerApi.V1 qualified as PV1
+import PlutusTx.Coverage (CoverageData)
 import Test.QuickCheck.Monadic (PropertyM)
 
 -- Error types
@@ -362,6 +364,7 @@ data MockChainState era
   , mcsDatums :: Map (C.Hash C.ScriptData) C.HashableScriptData
   , mcsTxById :: Map C.TxId (C.Tx era)
   -- ^ Index of transactions by ID
+  , mcsCoverageData :: CoverageData
   }
 
 makeLensesFor
@@ -371,6 +374,7 @@ makeLensesFor
   , ("mcsFailedTransactions", "failedTransactions")
   , ("mcsDatums", "datums")
   , ("mcsTxById", "txById")
+  , ("mcsCoverageData", "coverageData")
   ]
   ''MockChainState
 

--- a/src/coin-selection/convex-coin-selection.cabal
+++ b/src/coin-selection/convex-coin-selection.cabal
@@ -59,6 +59,7 @@ library
     , exceptions
     , lens
     , ordered-containers
+    , plutus-tx
     , primitive
     , text
 

--- a/src/coin-selection/lib/Convex/CoinSelection.hs
+++ b/src/coin-selection/lib/Convex/CoinSelection.hs
@@ -33,6 +33,7 @@ module Convex.CoinSelection (
   txBody,
   changeOutput,
   numWitnesses,
+  coverageFromBalanceTxError,
 
   -- * Balancing
   BalanceTxError (..),
@@ -160,6 +161,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
 import GHC.IsList (IsList (fromList, toList))
+import PlutusTx.Coverage (CoverageData, coverageDataFromLogMsg)
 
 type ERA = ConwayEra
 
@@ -891,3 +893,8 @@ publicKeyCredential = preview (L._TxOut . _1 . L._ShelleyAddress . _2 . L._Shell
 spendPubKeyTxIn :: C.TxIn -> (C.TxIn, C.BuildTxWith C.BuildTx (C.Witness C.WitCtxTxIn era))
 -- TODO: consolidate with Convex.BuildTx.spendPublicKeyOutput
 spendPubKeyTxIn txIn = (txIn, C.BuildTxWith (C.KeyWitness C.KeyWitnessForSpending))
+
+coverageFromBalanceTxError :: BalanceTxError e -> CoverageData
+coverageFromBalanceTxError (ABalancingError (ScriptExecutionErr errs)) =
+  foldMap (\(_, _, logs) -> foldMap (coverageDataFromLogMsg . Text.unpack) logs) errs
+coverageFromBalanceTxError _ = mempty

--- a/src/coin-selection/test/Scripts.hs
+++ b/src/coin-selection/test/Scripts.hs
@@ -21,7 +21,6 @@ module Scripts (
 where
 
 import Cardano.Api qualified as C
-import PlutusLedgerApi.Common (SerialisedScript)
 import PlutusLedgerApi.Test.Examples (alwaysSucceedingNAryFunction)
 
 #if __GLASGOW_HASKELL__ < 910
@@ -52,15 +51,14 @@ matchingIndexValidatorCompiled = $$(PlutusTx.compile [||MatchingIndex.matchingIn
 matchingIndexMPCompiled :: CompiledCode (BuiltinData -> BuiltinUnit)
 matchingIndexMPCompiled = $$(PlutusTx.compile [||MatchingIndex.matchingIndexMPScript||])
 
+{- | Script that passes if the input's index (in the list of transaction inputs)
+  matches the number passed as the redeemer
+-}
 matchingIndexValidatorScript :: C.PlutusScript C.PlutusScriptV3
 matchingIndexValidatorScript = compiledCodeToScript matchingIndexValidatorCompiled
 
 matchingIndexMPScript :: C.PlutusScript C.PlutusScriptV3
 matchingIndexMPScript = compiledCodeToScript matchingIndexMPCompiled
-
-{- | Script that passes if the input's index (in the list of transaction inputs)
-  matches the number passed as the redeemer
--}
 
 {- | Spend an output locked by 'matchingIndexValidatorScript', setting
 the redeemer to the index of the input in the final transaction

--- a/src/coin-selection/test/Scripts.hs
+++ b/src/coin-selection/test/Scripts.hs
@@ -9,9 +9,8 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 #endif
 
--- | Scripts used for testing
+-- | Scripts used for testing coin-selection
 module Scripts (
-  v2SpendingScriptSerialised,
   v2SpendingScript,
   v2StakingScript,
   matchingIndexValidatorScript,
@@ -38,12 +37,11 @@ import Scripts.MatchingIndex qualified as MatchingIndex
 #else
 #endif
 
+-- | V2 spending script (always succeeds, 3 args: datum, redeemer, context)
 v2SpendingScript :: C.PlutusScript C.PlutusScriptV2
 v2SpendingScript = C.PlutusScriptSerialised $ alwaysSucceedingNAryFunction 3
 
-v2SpendingScriptSerialised :: SerialisedScript
-v2SpendingScriptSerialised = alwaysSucceedingNAryFunction 3
-
+-- | V2 staking script (always succeeds, 2 args: redeemer, context)
 v2StakingScript :: C.PlutusScript C.PlutusScriptV2
 v2StakingScript = C.PlutusScriptSerialised $ alwaysSucceedingNAryFunction 2
 
@@ -54,14 +52,15 @@ matchingIndexValidatorCompiled = $$(PlutusTx.compile [||MatchingIndex.matchingIn
 matchingIndexMPCompiled :: CompiledCode (BuiltinData -> BuiltinUnit)
 matchingIndexMPCompiled = $$(PlutusTx.compile [||MatchingIndex.matchingIndexMPScript||])
 
-{- | Script that passes if the input's index (in the list of transaction inputs)
-  matches the number passed as the redeemer
--}
 matchingIndexValidatorScript :: C.PlutusScript C.PlutusScriptV3
 matchingIndexValidatorScript = compiledCodeToScript matchingIndexValidatorCompiled
 
 matchingIndexMPScript :: C.PlutusScript C.PlutusScriptV3
 matchingIndexMPScript = compiledCodeToScript matchingIndexMPCompiled
+
+{- | Script that passes if the input's index (in the list of transaction inputs)
+  matches the number passed as the redeemer
+-}
 
 {- | Spend an output locked by 'matchingIndexValidatorScript', setting
 the redeemer to the index of the input in the final transaction

--- a/src/coin-selection/test/Spec.hs
+++ b/src/coin-selection/test/Spec.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 

--- a/src/mockchain/convex-mockchain.cabal
+++ b/src/mockchain/convex-mockchain.cabal
@@ -66,7 +66,7 @@ library
   -- cardano dependencies
   build-depends:
     , cardano-api
-    , cardano-crypto-class         >=2.1.1.0
+    , cardano-crypto-class
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-babbage
@@ -78,3 +78,5 @@ library
     , ouroboros-consensus-cardano
     , plutus-core
     , plutus-ledger-api
+    , plutus-tx
+    , text

--- a/src/mockchain/lib/Convex/MockChain.hs
+++ b/src/mockchain/lib/Convex/MockChain.hs
@@ -85,7 +85,6 @@ import Cardano.Ledger.Alonzo.Core qualified as L
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
   CollectError,
   collectPlutusScriptsWithContext,
-  evalPlutusScripts,
  )
 import Cardano.Ledger.Alonzo.TxWits (unTxDats)
 import Cardano.Ledger.Api qualified as L
@@ -100,7 +99,7 @@ import Cardano.Ledger.Conway.State (ConwayEraAccounts (..))
 import Cardano.Ledger.Core qualified as Core
 import Cardano.Ledger.Plutus.Evaluate (
   PlutusWithContext (..),
-  ScriptResult (..),
+  evaluatePlutusWithContext,
  )
 import Cardano.Ledger.Plutus.Language (
   LegacyPlutusArgs (..),
@@ -138,6 +137,7 @@ import Control.Lens (
   to,
   view,
   (%=),
+  (%~),
   (&),
   (.=),
   (.~),
@@ -178,6 +178,7 @@ import Convex.Class (
   MonadUtxoQuery (..),
   SendTxError (..),
   ValidationError (..),
+  coverageData,
   datums,
   env,
   failedTransactions,
@@ -212,17 +213,21 @@ import Convex.Wallet (
  )
 import Data.Bifunctor (Bifunctor (..))
 import Data.Default (Default (def))
+import Data.Either (isRight)
 import Data.Foldable (for_, traverse_)
 import Data.Functor.Identity (Identity (..))
 import Data.Map qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as T
 import PlutusCore qualified as PLC
 import PlutusLedgerApi.Common (
   PlutusLedgerLanguage (..),
+  VerboseMode (..),
   mkTermToEvaluate,
  )
 import PlutusLedgerApi.Common qualified as Plutus
 import PlutusLedgerApi.V3 qualified as PV3
+import PlutusTx.Coverage (CoverageData, coverageDataFromLogMsg)
 import UntypedPlutusCore qualified as UPLC
 
 {- | Apply the plutus script to all its arguments and return a plutus
@@ -347,6 +352,7 @@ initialStateFor params@NodeParams{npNetworkId} utxos =
           , mcsFailedTransactions = []
           , mcsDatums = Map.empty
           , mcsTxById = Map.empty
+          , mcsCoverageData = mempty
           }
 
 utxoEnv :: (Ledger.EraCertState (C.ShelleyLedgerEra era)) => NodeParams era -> SlotNo -> UtxoEnv (C.ShelleyLedgerEra era)
@@ -367,11 +373,13 @@ getTxExUnits NodeParams{npSystemStart, npEraHistory, npProtocolParameters} utxo 
       rdmrs -> traverse (either (Left . Phase2Error) (Right . snd)) rdmrs
 
 applyTransaction :: forall era. (EraStake (C.ShelleyLedgerEra era), C.IsEra era, C.IsAlonzoBasedEra era) => NodeParams era -> MockChainState era -> C.Tx era -> Either (SendTxError era) (MockChainState era, Validated (Core.Tx (C.ShelleyLedgerEra era)))
-applyTransaction params state' tx'@(C.ShelleyTx _era tx) = C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $ do
-  let currentSlot = state' ^. env . L.slot
-      utxoState_ = state' ^. poolState . L.utxoState
+applyTransaction params oldState tx'@(C.ShelleyTx _era tx) = C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $ do
+  let currentSlot = oldState ^. env . L.slot
+      utxoState_ = oldState ^. poolState . L.utxoState
       utxo = utxoState_ ^. L._UTxOState . _1
-  (vtx, scripts) <- first (MockchainError . CollectErrors) (constructValidated (Defaults.globals params) (utxoEnv params currentSlot) utxoState_ tx)
+  (vtx, scripts, covData) <- first (MockchainError . CollectErrors) (constructValidated (Defaults.globals params) (utxoEnv params currentSlot) utxoState_ tx)
+  -- add coverage data to the state
+  let state' = oldState & coverageData %~ (<>) covData
   result <- applyTx params state' vtx scripts
 
   -- Not sure if this step is needed.
@@ -384,8 +392,9 @@ applyTransaction params state' tx'@(C.ShelleyTx _era tx) = C.alonzoEraOnwardsCon
 -- | Evaluate a transaction, returning all of its script contexts.
 evaluateTx :: NodeParams C.ConwayEra -> SlotNo -> UTxO L.ConwayEra -> C.Tx C.ConwayEra -> Either (SendTxError C.ConwayEra) [PlutusWithContext]
 evaluateTx params slotNo utxo (C.ShelleyTx _ tx) = do
-  (vtx, scripts) <- first (MockchainError . CollectErrors) (constructValidated (Defaults.globals params) (utxoEnv params slotNo) (lsUTxOState (mcsPoolState state')) tx)
-  _ <- applyTx params state' vtx scripts
+  (vtx, scripts, covData) <- first (MockchainError . CollectErrors) (constructValidated (Defaults.globals params) (utxoEnv params slotNo) (lsUTxOState (mcsPoolState state')) tx)
+  let stateWithCovData = state' & coverageData %~ (<>) covData
+  _ <- applyTx params stateWithCovData vtx scripts
   pure scripts
  where
   state' =
@@ -412,22 +421,33 @@ constructValidated
   -> UtxoEnv (C.ShelleyLedgerEra era)
   -> UTxOState (C.ShelleyLedgerEra era)
   -> Core.Tx (C.ShelleyLedgerEra era)
-  -> m (Core.Tx (C.ShelleyLedgerEra era), [PlutusWithContext])
+  -> m (Core.Tx (C.ShelleyLedgerEra era), [PlutusWithContext], CoverageData)
 constructValidated globals (UtxoEnv _ pp _) st tx =
   C.alonzoEraOnwardsConstraints @era C.alonzoBasedEra $
     alonzoEraUtxo @era $
       case collectPlutusScriptsWithContext ei sysS pp tx utxo of
         Left errs -> throwError errs
         Right sLst ->
-          let scriptEvalResult = evalPlutusScripts sLst
-              vTx = set L.isValidTxL (IsValid (lift_ scriptEvalResult)) tx
-           in pure (vTx, sLst)
+          let
+            -- Evaluate each script individually to get traces
+            scriptResults = map (evaluatePlutusWithContext Verbose) sLst
+            -- Extract logs and check if validation passed
+            allLogs = concatMap fst scriptResults
+            validationPassed = all (isRight . snd) scriptResults
+
+            -- Format logs for display
+            logsStrLines = map T.unpack allLogs
+            allCoverageData = map coverageDataFromLogMsg logsStrLines
+            -- mappend allCoverageData
+            covData = mconcat allCoverageData
+
+            vTx = set L.isValidTxL (IsValid validationPassed) tx
+           in
+            pure (vTx, sLst, covData)
  where
   utxo = utxosUtxo st
   sysS = systemStart globals
   ei = epochInfo globals
-  lift_ (Passes _) = True
-  lift_ (Fails _ _) = False
 
 applyTx
   :: forall era

--- a/src/wallet/lib/Convex/Wallet.hs
+++ b/src/wallet/lib/Convex/Wallet.hs
@@ -60,6 +60,9 @@ import GHC.IsList (IsList (toList))
 
 newtype Wallet = Wallet {getWallet :: SigningKey PaymentKey}
 
+instance Eq Wallet where
+  Wallet sk1 == Wallet sk2 = C.serialiseToRawBytes sk1 == C.serialiseToRawBytes sk2
+
 instance ToJSON Wallet where
   toJSON k = object ["private_key" .= privateKey k]
 


### PR DESCRIPTION
 ### Summary

These changes support the `convex-testing-interface` package (developed in [sc-testing-tools](https://github.com/input-output-hk/sc-testing-tools) ) which needs:

1. Plutus script coverage data from the mockchain -- the testing interface runs threat models and property-based tests, and needs to report which code paths in Plutus scripts were exercised.
3. A `setValidityRangeSlots` helper in BuildTx -- the testing interface constructs transactions with specific slot-based validity ranges.
5. An `Eq` instance for `Wallet` -- needed for comparing wallets in test actions.

#### Changes:

- `feat(mockchain): add plutus-tx coverage support` commit
  - Adds `mcsCoverageData` field to `MockChainState`
  - Replaces `evalPlutusScripts` with`evaluatePlutusWithContext` in `constructValidated` to capture per-script execution traces
  - Collects `CoverageData` from script logs via `coverageDataFromLogMsg` and accumulates it across transactions
  - Adds `coverageFromBalanceTxError` helper in `CoinSelection` to extract coverage data from failed script executions
  - Adds `plutus-tx` dependency to `convex-mockchain` and convex-coin-selection

- `setValidityRangeSlots and Eq Wallet` commit
  - Adds `setValidityRangeSlots` to Convex.BuildTx 
  - Adds `Eq` for Wallet

#### Why?

The `convex-testing-interface` package (property-based testing + threat models) depends on these `sc-tools` features. Without them, we can't:
- Report Plutus script coverage from `mockchain` test runs
- Build transactions with slot-based validity ranges
